### PR TITLE
Refactor LLM init logic

### DIFF
--- a/src/utils/agent_utils.py
+++ b/src/utils/agent_utils.py
@@ -1,0 +1,42 @@
+import logging
+from typing import Optional
+
+import gradio as gr
+from langchain_core.language_models.chat_models import BaseChatModel
+
+from src.utils import llm_provider
+
+logger = logging.getLogger(__name__)
+
+
+async def initialize_llm(
+    provider: Optional[str],
+    model_name: Optional[str],
+    temperature: float,
+    base_url: Optional[str],
+    api_key: Optional[str],
+    num_ctx: Optional[int] = None,
+) -> Optional[BaseChatModel]:
+    """Initializes the LLM based on settings. Returns None if provider/model is missing."""
+    if not provider or not model_name:
+        logger.info("LLM Provider or Model Name not specified, LLM will be None.")
+        return None
+    try:
+        logger.info(
+            f"Initializing LLM: Provider={provider}, Model={model_name}, Temp={temperature}"
+        )
+        llm = llm_provider.get_llm_model(
+            provider=provider,
+            model_name=model_name,
+            temperature=temperature,
+            base_url=base_url or None,
+            api_key=api_key or None,
+            num_ctx=num_ctx if provider == "ollama" else None,
+        )
+        return llm
+    except Exception as e:
+        logger.error(f"Failed to initialize LLM: {e}", exc_info=True)
+        gr.Warning(
+            f"Failed to initialize LLM '{model_name}' for provider '{provider}'. Please check settings. Error: {e}"
+        )
+        return None

--- a/src/webui/components/browser_use_agent_tab.py
+++ b/src/webui/components/browser_use_agent_tab.py
@@ -22,49 +22,13 @@ from src.agent.browser_use.browser_use_agent import BrowserUseAgent
 from src.browser.custom_browser import CustomBrowser
 from src.browser.custom_context import CustomBrowserContextConfig
 from src.controller.custom_controller import CustomController
-from src.utils import llm_provider
+from src.utils.agent_utils import initialize_llm  #(import initialize_llm utility)
 from src.webui.webui_manager import WebuiManager
 
 logger = logging.getLogger(__name__)
 
 
 # --- Helper Functions --- (Defined at module level)
-
-
-async def _initialize_llm(
-    provider: Optional[str],
-    model_name: Optional[str],
-    temperature: float,
-    base_url: Optional[str],
-    api_key: Optional[str],
-    num_ctx: Optional[int] = None,
-) -> Optional[BaseChatModel]:
-    """Initializes the LLM based on settings. Returns None if provider/model is missing."""
-    if not provider or not model_name:
-        logger.info("LLM Provider or Model Name not specified, LLM will be None.")
-        return None
-    try:
-        # Use your actual LLM provider logic here
-        logger.info(
-            f"Initializing LLM: Provider={provider}, Model={model_name}, Temp={temperature}"
-        )
-        # Example using a placeholder function
-        llm = llm_provider.get_llm_model(
-            provider=provider,
-            model_name=model_name,
-            temperature=temperature,
-            base_url=base_url or None,
-            api_key=api_key or None,
-            # Add other relevant params like num_ctx for ollama
-            num_ctx=num_ctx if provider == "ollama" else None,
-        )
-        return llm
-    except Exception as e:
-        logger.error(f"Failed to initialize LLM: {e}", exc_info=True)
-        gr.Warning(
-            f"Failed to initialize LLM '{model_name}' for provider '{provider}'. Please check settings. Error: {e}"
-        )
-        return None
 
 
 def _get_config_value(
@@ -366,7 +330,7 @@ async def run_agent_task(
         planner_llm_api_key = get_setting("planner_llm_api_key") or None
         planner_use_vision = get_setting("planner_use_vision", False)
 
-        planner_llm = await _initialize_llm(
+        planner_llm = await initialize_llm(  #(use shared initialize_llm utility)
             planner_llm_provider_name,
             planner_llm_model_name,
             planner_llm_temperature,
@@ -411,7 +375,7 @@ async def run_agent_task(
         os.makedirs(save_download_path, exist_ok=True)
 
     # --- 2. Initialize LLM ---
-    main_llm = await _initialize_llm(
+    main_llm = await initialize_llm(  #(use shared initialize_llm utility)
         llm_provider_name,
         llm_model_name,
         llm_temperature,

--- a/src/webui/components/deep_research_agent_tab.py
+++ b/src/webui/components/deep_research_agent_tab.py
@@ -10,34 +10,11 @@ from typing import Any, Dict, AsyncGenerator, Optional, Tuple, Union
 import asyncio
 import json
 from src.agent.deep_research.deep_research_agent import DeepResearchAgent
-from src.utils import llm_provider
+from src.utils.agent_utils import initialize_llm  #(import initialize_llm utility)
 
 logger = logging.getLogger(__name__)
 
 
-async def _initialize_llm(provider: Optional[str], model_name: Optional[str], temperature: float,
-                          base_url: Optional[str], api_key: Optional[str], num_ctx: Optional[int] = None):
-    """Initializes the LLM based on settings. Returns None if provider/model is missing."""
-    if not provider or not model_name:
-        logger.info("LLM Provider or Model Name not specified, LLM will be None.")
-        return None
-    try:
-        logger.info(f"Initializing LLM: Provider={provider}, Model={model_name}, Temp={temperature}")
-        # Use your actual LLM provider logic here
-        llm = llm_provider.get_llm_model(
-            provider=provider,
-            model_name=model_name,
-            temperature=temperature,
-            base_url=base_url or None,
-            api_key=api_key or None,
-            num_ctx=num_ctx if provider == "ollama" else None
-        )
-        return llm
-    except Exception as e:
-        logger.error(f"Failed to initialize LLM: {e}", exc_info=True)
-        gr.Warning(
-            f"Failed to initialize LLM '{model_name}' for provider '{provider}'. Please check settings. Error: {e}")
-        return None
 
 
 def _read_file_safe(file_path: str) -> Optional[str]:
@@ -121,7 +98,7 @@ async def run_deep_research(webui_manager: WebuiManager, components: Dict[Compon
         llm_api_key = get_setting("agent_settings", "llm_api_key")
         ollama_num_ctx = get_setting("agent_settings", "ollama_num_ctx")
 
-        llm = await _initialize_llm(
+        llm = await initialize_llm(  #(use shared initialize_llm utility)
             llm_provider_name, llm_model_name, llm_temperature, llm_base_url, llm_api_key,
             ollama_num_ctx if llm_provider_name == "ollama" else None
         )


### PR DESCRIPTION
## Summary
- centralize llm initialization logic in `initialize_llm`
- replace custom functions in browser and research tabs with shared utility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*