### PR TITLE
Refactor MCP config loading

### DIFF
--- a/src/utils/agent_utils.py
+++ b/src/utils/agent_utils.py
@@ -1,0 +1,18 @@
+import os  # //(new file import os for file checks)
+import json  # //(new file import json to load config)
+import gradio as gr  # //(new file import gradio for UI updates)
+import logging  # //(new file import logging for warnings)
+
+logger = logging.getLogger(__name__)  # //(new logger for debugging)
+
+
+async def load_mcp_server_config(mcp_file: str):  # //(new util to load MCP config)
+    """Load MCP server JSON and return display data."""  # //(docstring for new function)
+    if not mcp_file or not os.path.exists(mcp_file) or not mcp_file.endswith('.json'):  # //(validate file path)
+        logger.warning(f"{mcp_file} is not a valid MCP file.")  # //(log warning for invalid path)
+        return None, gr.update(visible=False)  # //(return invisibility for bad file)
+
+    with open(mcp_file, 'r') as f:  # //(open provided json file)
+        mcp_server = json.load(f)  # //(parse json content)
+
+    return json.dumps(mcp_server, indent=2), gr.update(visible=True)  # //(return serialized json and visible update)

--- a/src/webui/components/agent_settings_tab.py
+++ b/src/webui/components/agent_settings_tab.py
@@ -1,5 +1,4 @@
-import json
-import os
+from src.utils.agent_utils import load_mcp_server_config  # //(use util to load MCP json)
 
 import gradio as gr
 from gradio.components import Component
@@ -7,7 +6,6 @@ from typing import Any, Dict, Optional
 from src.webui.webui_manager import WebuiManager
 from src.utils import config
 import logging
-from functools import partial
 
 logger = logging.getLogger(__name__)
 
@@ -33,14 +31,7 @@ async def update_mcp_server(mcp_file: str, webui_manager: WebuiManager):
         await webui_manager.bu_controller.close_mcp_client()
         webui_manager.bu_controller = None
 
-    if not mcp_file or not os.path.exists(mcp_file) or not mcp_file.endswith('.json'):
-        logger.warning(f"{mcp_file} is not a valid MCP file.")
-        return None, gr.update(visible=False)
-
-    with open(mcp_file, 'r') as f:
-        mcp_server = json.load(f)
-
-    return json.dumps(mcp_server, indent=2), gr.update(visible=True)
+    return await load_mcp_server_config(mcp_file)  # //(delegate JSON loading)
 
 
 def create_agent_settings_tab(webui_manager: WebuiManager):

--- a/src/webui/components/deep_research_agent_tab.py
+++ b/src/webui/components/deep_research_agent_tab.py
@@ -1,6 +1,6 @@
 import gradio as gr
 from gradio.components import Component
-from functools import partial
+from src.utils.agent_utils import load_mcp_server_config  # //(use util for MCP json)
 
 from src.webui.webui_manager import WebuiManager
 from src.utils import config
@@ -357,14 +357,7 @@ async def update_mcp_server(mcp_file: str, webui_manager: WebuiManager):
         logger.warning("⚠️ Close controller because mcp file has changed!")
         await webui_manager.dr_agent.close_mcp_client()
 
-    if not mcp_file or not os.path.exists(mcp_file) or not mcp_file.endswith('.json'):
-        logger.warning(f"{mcp_file} is not a valid MCP file.")
-        return None, gr.update(visible=False)
-
-    with open(mcp_file, 'r') as f:
-        mcp_server = json.load(f)
-
-    return json.dumps(mcp_server, indent=2), gr.update(visible=True)
+    return await load_mcp_server_config(mcp_file)  # //(delegate JSON loading)
 
 
 def create_deep_research_agent_tab(webui_manager: WebuiManager):


### PR DESCRIPTION
## Summary
- centralize MCP server config reading in `load_mcp_server_config`
- use new helper in Agent Settings and Deep Research tabs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*