### PR TITLE
Integrate safe JSON loader

### DIFF
--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -1,0 +1,13 @@
+import json, logging, os  # //new utility imports for safe json loading
+logger = logging.getLogger(__name__)  # //logger setup for this module
+
+
+def load_json_safe(path: str):  # //utility to safely load json
+    if not path or not os.path.exists(path):  # //validate path exists
+        return None  # //return None if invalid
+    try:
+        with open(path, "r", encoding="utf-8") as f:  # //open file safely
+            return json.load(f)  # //return parsed json
+    except Exception as e:  # //catch any exception during load
+        logger.error(f"Failed loading {path}: {e}")  # //log failure
+        return None  # //return None on failure

--- a/src/webui/components/agent_settings_tab.py
+++ b/src/webui/components/agent_settings_tab.py
@@ -6,6 +6,7 @@ from gradio.components import Component
 from typing import Any, Dict, Optional
 from src.webui.webui_manager import WebuiManager
 from src.utils import config
+from src.utils.file_utils import load_json_safe  # //import safe json loader
 import logging
 from functools import partial
 
@@ -34,11 +35,13 @@ async def update_mcp_server(mcp_file: str, webui_manager: WebuiManager):
         webui_manager.bu_controller = None
 
     if not mcp_file or not os.path.exists(mcp_file) or not mcp_file.endswith('.json'):
-        logger.warning(f"{mcp_file} is not a valid MCP file.")
-        return None, gr.update(visible=False)
+        logger.warning(f"{mcp_file} is not a valid MCP file.")  # //warn invalid file
+        return None, gr.update(visible=False)  # //hide textbox when invalid
 
-    with open(mcp_file, 'r') as f:
-        mcp_server = json.load(f)
+    mcp_server = load_json_safe(mcp_file)  # //use utility to load json safely
+    if mcp_server is None:  # //check load failure
+        logger.warning(f"{mcp_file} cannot be loaded.")  # //log warning on failure
+        return None, gr.update(visible=False)  # //hide textbox if load fails
 
     return json.dumps(mcp_server, indent=2), gr.update(visible=True)
 


### PR DESCRIPTION
## Summary
- add a utility helper for safely loading JSON files
- use the safe loader inside agent settings tab

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*