### PR TITLE
Add browser cleanup helper and refactor settings

### DIFF
--- a/src/utils/browser_cleanup.py
+++ b/src/utils/browser_cleanup.py
@@ -1,0 +1,16 @@
+import logging
+logger = logging.getLogger(__name__)
+
+async def close_browser_resources(browser, context):
+    if context:
+        logger.info("⚠️ Closing browser context when changing browser config.")  # //log context closing
+        try:
+            await context.close()
+        except Exception as e:
+            logger.error(f"Error closing context: {e}")
+    if browser:
+        logger.info("⚠️ Closing browser when changing browser config.")  # //log browser closing
+        try:
+            await browser.close()
+        except Exception as e:
+            logger.error(f"Error closing browser: {e}")

--- a/src/webui/components/browser_settings_tab.py
+++ b/src/webui/components/browser_settings_tab.py
@@ -3,7 +3,8 @@ import logging
 from gradio.components import Component
 
 from src.webui.webui_manager import WebuiManager
-from src.utils import config
+from src.utils import config  # //(existing config import remains)
+from src.utils.browser_cleanup import close_browser_resources  # //(imported shared cleanup)
 
 logger = logging.getLogger(__name__)
 
@@ -15,15 +16,12 @@ async def close_browser(webui_manager: WebuiManager):
         webui_manager.bu_current_task.cancel()
         webui_manager.bu_current_task = None
 
-    if webui_manager.bu_browser_context:
-        logger.info("⚠️ Closing browser context when changing browser config.")
-        await webui_manager.bu_browser_context.close()
-        webui_manager.bu_browser_context = None
-
-    if webui_manager.bu_browser:
-        logger.info("⚠️ Closing browser when changing browser config.")
-        await webui_manager.bu_browser.close()
-        webui_manager.bu_browser = None
+    await close_browser_resources(  # //(using shared util to close resources)
+        webui_manager.bu_browser,
+        webui_manager.bu_browser_context,
+    )
+    webui_manager.bu_browser_context = None  # //(reset context reference)
+    webui_manager.bu_browser = None  # //(reset browser reference)
 
 def create_browser_settings_tab(webui_manager: WebuiManager):
     """


### PR DESCRIPTION
## Summary
- centralize browser cleanup logic in new `close_browser_resources` utility
- reuse the utility in `close_browser` inside browser settings tab
- restore info logs when closing browser resources

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*