### PR TITLE
Normalize comment style

### DIFF
--- a/src/agent/deep_research/deep_research_agent.py
+++ b/src/agent/deep_research/deep_research_agent.py
@@ -34,7 +34,7 @@ from src.browser.custom_browser import CustomBrowser
 from src.browser.custom_context import CustomBrowserContextConfig
 from src.controller.custom_controller import CustomController
 from src.utils.mcp_client import setup_mcp_client_and_tools
-from src.utils.browser_launch import build_browser_launch_options  # // import util for browser launch options
+from src.utils.browser_launch import build_browser_launch_options  # import util for browser launch options
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +79,7 @@ async def run_single_browser_task(
     bu_browser_context = None
     try:
         logger.info(f"Starting browser task for query: {task_query}")
-        browser_binary_path, extra_args = build_browser_launch_options(browser_config)  # // util handles user data dir & own browser
+        browser_binary_path, extra_args = build_browser_launch_options(browser_config)  # handles user data dir and custom browser
 
         bu_browser = CustomBrowser(
             config=BrowserConfig(

--- a/src/utils/browser_cleanup.py
+++ b/src/utils/browser_cleanup.py
@@ -3,13 +3,13 @@ logger = logging.getLogger(__name__)
 
 async def close_browser_resources(browser, context):
     if context:
-        logger.info("⚠️ Closing browser context when changing browser config.")  # //log context closing
+        logger.info("⚠️ Closing browser context when changing browser config.")  # log context closing
         try:
             await context.close()
         except Exception as e:
             logger.error(f"Error closing context: {e}")
     if browser:
-        logger.info("⚠️ Closing browser when changing browser config.")  # //log browser closing
+        logger.info("⚠️ Closing browser when changing browser config.")  # log browser closing
         try:
             await browser.close()
         except Exception as e:

--- a/src/utils/browser_launch.py
+++ b/src/utils/browser_launch.py
@@ -1,24 +1,24 @@
-import os  # // needed for env lookup
-from typing import Any, Dict, List, Optional, Tuple  # // typing for function
+import os  # needed for env lookup
+from typing import Any, Dict, List, Optional, Tuple  # typing for function
 
 
-def build_browser_launch_options(config: Dict[str, Any]) -> Tuple[Optional[str], List[str]]:  # // util to build browser options
-    """Build browser binary path and extra launch arguments."""  # // describe function
-    window_w = config.get("window_width", 1280)  # // width from config
-    window_h = config.get("window_height", 1100)  # // height from config
-    extra_args = [f"--window-size={window_w},{window_h}"]  # // default arg list
-    browser_user_data_dir = config.get("user_data_dir", None)  # // custom data dir
+def build_browser_launch_options(config: Dict[str, Any]) -> Tuple[Optional[str], List[str]]:  # build browser options
+    """Build browser binary path and extra launch arguments."""  # function description
+    window_w = config.get("window_width", 1280)  # width from config
+    window_h = config.get("window_height", 1100)  # height from config
+    extra_args = [f"--window-size={window_w},{window_h}"]  # default arg list
+    browser_user_data_dir = config.get("user_data_dir", None)  # custom data dir
     if browser_user_data_dir:
-        extra_args.append(f"--user-data-dir={browser_user_data_dir}")  # // add dir option
-    use_own_browser = config.get("use_own_browser", False)  # // check custom browser usage
-    browser_binary_path = config.get("browser_binary_path", None)  # // path from config
+        extra_args.append(f"--user-data-dir={browser_user_data_dir}")  # add dir option
+    use_own_browser = config.get("use_own_browser", False)  # check custom browser usage
+    browser_binary_path = config.get("browser_binary_path", None)  # path from config
     if use_own_browser:
-        browser_binary_path = os.getenv("CHROME_PATH", None) or browser_binary_path  # // env override
+        browser_binary_path = os.getenv("CHROME_PATH", None) or browser_binary_path  # env override
         if browser_binary_path == "":
-            browser_binary_path = None  # // empty -> None
-        chrome_user_data = os.getenv("CHROME_USER_DATA", None)  # // check env data dir
+            browser_binary_path = None  # empty -> None
+        chrome_user_data = os.getenv("CHROME_USER_DATA", None)  # check env data dir
         if chrome_user_data:
-            extra_args.append(f"--user-data-dir={chrome_user_data}")  # // add env dir
+            extra_args.append(f"--user-data-dir={chrome_user_data}")  # add env dir
     else:
-        browser_binary_path = None  # // not using custom browser
-    return browser_binary_path, extra_args  # // return values
+        browser_binary_path = None  # not using custom browser
+    return browser_binary_path, extra_args  # return values

--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -1,13 +1,13 @@
-import json, logging, os  # //new utility imports for safe json loading
-logger = logging.getLogger(__name__)  # //logger setup for this module
+import json, logging, os  # new utility imports for safe json loading
+logger = logging.getLogger(__name__)  # logger setup for this module
 
 
-def load_json_safe(path: str):  # //utility to safely load json
-    if not path or not os.path.exists(path):  # //validate path exists
-        return None  # //return None if invalid
+def load_json_safe(path: str):  # utility to safely load json
+    if not path or not os.path.exists(path):  # validate path exists
+        return None  # return None if invalid
     try:
-        with open(path, "r", encoding="utf-8") as f:  # //open file safely
-            return json.load(f)  # //return parsed json
-    except Exception as e:  # //catch any exception during load
-        logger.error(f"Failed loading {path}: {e}")  # //log failure
-        return None  # //return None on failure
+        with open(path, "r", encoding="utf-8") as f:  # open file safely
+            return json.load(f)  # return parsed json
+    except Exception as e:  # catch any exception during load
+        logger.error(f"Failed loading {path}: {e}")  # log failure
+        return None  # return None on failure

--- a/src/webui/components/agent_settings_tab.py
+++ b/src/webui/components/agent_settings_tab.py
@@ -6,7 +6,7 @@ from gradio.components import Component
 from typing import Any, Dict, Optional
 from src.webui.webui_manager import WebuiManager
 from src.utils import config
-from src.utils.file_utils import load_json_safe  # //import safe json loader
+from src.utils.file_utils import load_json_safe  # import safe json loader
 import logging
 from functools import partial
 
@@ -35,13 +35,13 @@ async def update_mcp_server(mcp_file: str, webui_manager: WebuiManager):
         webui_manager.bu_controller = None
 
     if not mcp_file or not os.path.exists(mcp_file) or not mcp_file.endswith('.json'):
-        logger.warning(f"{mcp_file} is not a valid MCP file.")  # //warn invalid file
-        return None, gr.update(visible=False)  # //hide textbox when invalid
+        logger.warning(f"{mcp_file} is not a valid MCP file.")  # warn invalid file
+        return None, gr.update(visible=False)  # hide textbox when invalid
 
-    mcp_server = load_json_safe(mcp_file)  # //use utility to load json safely
-    if mcp_server is None:  # //check load failure
-        logger.warning(f"{mcp_file} cannot be loaded.")  # //log warning on failure
-        return None, gr.update(visible=False)  # //hide textbox if load fails
+    mcp_server = load_json_safe(mcp_file)  # load json safely
+    if mcp_server is None:  # check load failure
+        logger.warning(f"{mcp_file} cannot be loaded.")  # log warning on failure
+        return None, gr.update(visible=False)  # hide textbox if load fails
 
     return json.dumps(mcp_server, indent=2), gr.update(visible=True)
 

--- a/src/webui/components/browser_settings_tab.py
+++ b/src/webui/components/browser_settings_tab.py
@@ -3,8 +3,8 @@ import logging
 from gradio.components import Component
 
 from src.webui.webui_manager import WebuiManager
-from src.utils import config  # //(existing config import remains)
-from src.utils.browser_cleanup import close_browser_resources  # //(imported shared cleanup)
+from src.utils import config  # existing config import
+from src.utils.browser_cleanup import close_browser_resources  # shared cleanup utility
 
 logger = logging.getLogger(__name__)
 
@@ -16,12 +16,12 @@ async def close_browser(webui_manager: WebuiManager):
         webui_manager.bu_current_task.cancel()
         webui_manager.bu_current_task = None
 
-    await close_browser_resources(  # //(using shared util to close resources)
+    await close_browser_resources(  # use shared util to close resources
         webui_manager.bu_browser,
         webui_manager.bu_browser_context,
     )
-    webui_manager.bu_browser_context = None  # //(reset context reference)
-    webui_manager.bu_browser = None  # //(reset browser reference)
+    webui_manager.bu_browser_context = None  # reset context reference
+    webui_manager.bu_browser = None  # reset browser reference
 
 def create_browser_settings_tab(webui_manager: WebuiManager):
     """

--- a/tests/test_browser_launch.py
+++ b/tests/test_browser_launch.py
@@ -1,47 +1,47 @@
-import os  # // access env vars
-import sys  # // access sys path
+import os  # access env vars
+import sys  # access sys path
 
-sys.path.append(".")  # // allow src import
-from src.utils.browser_launch import build_browser_launch_options  # // import util
-
-
-def test_default_behavior_without_env(monkeypatch):  # // ensure defaults
-    monkeypatch.delenv("CHROME_PATH", raising=False)  # // remove env path
-    monkeypatch.delenv("CHROME_USER_DATA", raising=False)  # // remove env data
-    config = {"window_width": 800, "window_height": 600, "use_own_browser": False}  # // default config
-    path, args = build_browser_launch_options(config)  # // call util
-    assert path is None  # // expect None path
-    assert args == ["--window-size=800,600"]  # // only window size
+sys.path.append(".")  # allow src import
+from src.utils.browser_launch import build_browser_launch_options  # import util
 
 
-def test_own_browser_env(monkeypatch):  # // env overrides
-    monkeypatch.setenv("CHROME_PATH", "/env/chrome")  # // set env path
-    monkeypatch.setenv("CHROME_USER_DATA", "/env/profile")  # // set env data
+def test_default_behavior_without_env(monkeypatch):  # ensure defaults
+    monkeypatch.delenv("CHROME_PATH", raising=False)  # remove env path
+    monkeypatch.delenv("CHROME_USER_DATA", raising=False)  # remove env data
+    config = {"window_width": 800, "window_height": 600, "use_own_browser": False}  # default config
+    path, args = build_browser_launch_options(config)  # call util
+    assert path is None  # expect None path
+    assert args == ["--window-size=800,600"]  # only window size
+
+
+def test_own_browser_env(monkeypatch):  # env overrides
+    monkeypatch.setenv("CHROME_PATH", "/env/chrome")  # set env path
+    monkeypatch.setenv("CHROME_USER_DATA", "/env/profile")  # set env data
     config = {
         "window_width": 640,
         "window_height": 480,
         "use_own_browser": True,
         "browser_binary_path": "/config/chrome",
         "user_data_dir": "/config/profile",
-    }  # // config with fields
-    path, args = build_browser_launch_options(config)  # // call util
-    assert path == "/env/chrome"  # // env path used
+    }  # config with fields
+    path, args = build_browser_launch_options(config)  # call util
+    assert path == "/env/chrome"  # env path used
     assert args == [
         "--window-size=640,480",
         "--user-data-dir=/config/profile",
         "--user-data-dir=/env/profile",
-    ]  # // all args present
+    ]  # all args present
 
 
-def test_empty_env_path(monkeypatch):  # // empty path becomes None
-    monkeypatch.setenv("CHROME_PATH", "")  # // empty env value
-    monkeypatch.delenv("CHROME_USER_DATA", raising=False)  # // no env data
+def test_empty_env_path(monkeypatch):  # empty path becomes None
+    monkeypatch.setenv("CHROME_PATH", "")  # empty env value
+    monkeypatch.delenv("CHROME_USER_DATA", raising=False)  # no env data
     config = {
         "window_width": 1024,
         "window_height": 768,
         "use_own_browser": True,
         # no browser_binary_path to test env empty string
-    }  # // config no binary path
-    path, args = build_browser_launch_options(config)  # // call util
-    assert path is None  # // empty env results in None
-    assert args == ["--window-size=1024,768"]  # // only window size arg
+    }  # config no binary path
+    path, args = build_browser_launch_options(config)  # call util
+    assert path is None  # empty env results in None
+    assert args == ["--window-size=1024,768"]  # only window size arg


### PR DESCRIPTION
## Summary
- normalize comments using standard Python `#`
- keep concise notes in deep research agent
- tidy agent and browser setting components
- clarify utils module comments
- adjust test comments for consistency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*