### PR TITLE
Fix duplicate pydantic import

### DIFF
--- a/src/utils/mcp_client.py
+++ b/src/utils/mcp_client.py
@@ -8,8 +8,7 @@ from typing import Any, Dict, List, Optional, Set, Type, Union, get_type_hints
 from browser_use.controller.registry.views import ActionModel
 from langchain.tools import BaseTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
-from pydantic import BaseModel, Field, create_model
-from pydantic.v1 import BaseModel, Field
+from pydantic import BaseModel, Field, create_model  # ensure single import for BaseModel and Field
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- remove duplicate pydantic import in `mcp_client`

## Testing
- `python -m py_compile src/utils/mcp_client.py`
- `pytest tests/test_browser_launch.py -q`