### PR TITLE
Remove debugger imports

### DIFF
--- a/src/browser/custom_browser.py
+++ b/src/browser/custom_browser.py
@@ -1,5 +1,4 @@
 import asyncio
-import pdb
 
 from patchright.async_api import Browser as PlaywrightBrowser
 from patchright.async_api import (

--- a/src/controller/custom_controller.py
+++ b/src/controller/custom_controller.py
@@ -1,4 +1,3 @@
-import pdb
 
 from typing import Optional, Type, Callable, Dict, Any, Union, Awaitable, TypeVar
 from pydantic import BaseModel

--- a/src/utils/llm_provider.py
+++ b/src/utils/llm_provider.py
@@ -1,5 +1,4 @@
 from openai import OpenAI
-import pdb
 from langchain_openai import ChatOpenAI
 from langchain_core.globals import get_llm_cache
 from langchain_core.language_models.base import (


### PR DESCRIPTION
## Summary
- clean up leftover pdb imports

## Testing
- `ruff check .` *(fails: Found 208 errors)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*