### PR TITLE
Implement mcp server config loader

### DIFF
--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -11,3 +11,13 @@ def load_json_safe(path: str):  # utility to safely load json
     except Exception as e:  # catch any exception during load
         logger.error(f"Failed loading {path}: {e}")  # log failure
         return None  # return None on failure
+
+
+def load_mcp_server_config(path: str, logger) -> dict | None:  # load MCP server config with validation
+    if not path or not os.path.exists(path) or not path.endswith('.json'):  # validate path exists and is json
+        logger.warning(f"{path} is not a valid MCP file.")  # warn when invalid
+        return None  # return None on invalid path
+    data = load_json_safe(path)  # use existing safe loader
+    if data is None:  # check load failure
+        logger.warning(f"{path} cannot be loaded.")  # warn when loading fails
+    return data  # return parsed json or None

--- a/src/webui/components/agent_settings_tab.py
+++ b/src/webui/components/agent_settings_tab.py
@@ -1,12 +1,11 @@
-import json
-import os
+import json  # json module for dumps  #(keep json import)
 
 import gradio as gr
 from gradio.components import Component
 from typing import Any, Dict, Optional
 from src.webui.webui_manager import WebuiManager
 from src.utils import config
-from src.utils.file_utils import load_json_safe  # import safe json loader
+from src.utils.file_utils import load_mcp_server_config  # use new mcp loader
 import logging
 from functools import partial
 
@@ -34,14 +33,9 @@ async def update_mcp_server(mcp_file: str, webui_manager: WebuiManager):
         await webui_manager.bu_controller.close_mcp_client()
         webui_manager.bu_controller = None
 
-    if not mcp_file or not os.path.exists(mcp_file) or not mcp_file.endswith('.json'):
-        logger.warning(f"{mcp_file} is not a valid MCP file.")  # warn invalid file
-        return None, gr.update(visible=False)  # hide textbox when invalid
-
-    mcp_server = load_json_safe(mcp_file)  # load json safely
-    if mcp_server is None:  # check load failure
-        logger.warning(f"{mcp_file} cannot be loaded.")  # log warning on failure
-        return None, gr.update(visible=False)  # hide textbox if load fails
+    mcp_server = load_mcp_server_config(mcp_file, logger)  # load config via util
+    if mcp_server is None:  # handle invalid or failed load
+        return None, gr.update(visible=False)  # hide textbox when load fails
 
     return json.dumps(mcp_server, indent=2), gr.update(visible=True)
 

--- a/src/webui/components/deep_research_agent_tab.py
+++ b/src/webui/components/deep_research_agent_tab.py
@@ -6,6 +6,7 @@ from src.webui.webui_manager import WebuiManager
 from src.utils import config
 import logging
 import os
+from src.utils.file_utils import load_mcp_server_config  # shared mcp loader
 from typing import Any, Dict, AsyncGenerator, Optional, Tuple, Union
 import asyncio
 import json
@@ -335,12 +336,9 @@ async def update_mcp_server(mcp_file: str, webui_manager: WebuiManager):
         logger.warning("⚠️ Close controller because mcp file has changed!")
         await webui_manager.dr_agent.close_mcp_client()
 
-    if not mcp_file or not os.path.exists(mcp_file) or not mcp_file.endswith('.json'):
-        logger.warning(f"{mcp_file} is not a valid MCP file.")
-        return None, gr.update(visible=False)
-
-    with open(mcp_file, 'r') as f:
-        mcp_server = json.load(f)
+    mcp_server = load_mcp_server_config(mcp_file, logger)  # use shared loader
+    if mcp_server is None:  # handle invalid config
+        return None, gr.update(visible=False)  # hide textbox on fail
 
     return json.dumps(mcp_server, indent=2), gr.update(visible=True)
 


### PR DESCRIPTION
## Summary
- add `load_mcp_server_config` helper
- refactor agent settings tab to use new loader
- refactor deep research agent tab to reuse loader

## Testing
- `pytest -q tests/components/test_agent_settings_tab.py tests/webui/test_webui_manager.py`
