### PR TITLE
Use ensure_dir utility

### DIFF
--- a/src/agent/deep_research/deep_research_agent.py
+++ b/src/agent/deep_research/deep_research_agent.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import threading
+from src.utils.utils import ensure_dir  # // directory helper import
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TypedDict
@@ -998,7 +999,7 @@ class DeepResearchAgent:
 
         self.current_task_id = task_id if task_id else str(uuid.uuid4())
         output_dir = os.path.join(save_dir, self.current_task_id)
-        os.makedirs(output_dir, exist_ok=True)
+        ensure_dir(output_dir)  # // ensure output dir exists
 
         logger.info(
             f"[AsyncGen] Starting research task ID: {self.current_task_id} for topic: '{topic}'"

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -9,6 +9,10 @@ import gradio as gr
 import uuid
 
 
+def ensure_dir(path: str):
+    os.makedirs(path, exist_ok=True)  # create directory if missing
+
+
 def encode_image(img_path):
     if not img_path:
         return None
@@ -22,7 +26,7 @@ def get_latest_files(directory: str, file_types: list = ['.webm', '.zip']) -> Di
     latest_files: Dict[str, Optional[str]] = {ext: None for ext in file_types}
 
     if not os.path.exists(directory):
-        os.makedirs(directory, exist_ok=True)
+        ensure_dir(directory)  # create dir on demand
         return latest_files
 
     for file_type in file_types:

--- a/src/webui/components/browser_use_agent_tab.py
+++ b/src/webui/components/browser_use_agent_tab.py
@@ -25,6 +25,7 @@ from src.controller.custom_controller import CustomController
 from src.utils.agent_utils import initialize_llm  #(import initialize_llm utility)
 from src.utils.browser_launch import build_browser_launch_options  # // import util for browser launch options
 from src.webui.webui_manager import WebuiManager
+from src.utils.utils import ensure_dir  # // import directory util
 
 logger = logging.getLogger(__name__)
 
@@ -360,13 +361,13 @@ async def run_agent_task(
     stream_vw = 70
     stream_vh = int(70 * window_h // window_w)
 
-    os.makedirs(save_agent_history_path, exist_ok=True)
+    ensure_dir(save_agent_history_path)  # // ensure save history path
     if save_recording_path:
-        os.makedirs(save_recording_path, exist_ok=True)
+        ensure_dir(save_recording_path)  # // ensure recording path
     if save_trace_path:
-        os.makedirs(save_trace_path, exist_ok=True)
+        ensure_dir(save_trace_path)  # // ensure trace path
     if save_download_path:
-        os.makedirs(save_download_path, exist_ok=True)
+        ensure_dir(save_download_path)  # // ensure download path
 
     # --- 2. Initialize LLM ---
     main_llm = await initialize_llm(  #(use shared initialize_llm utility)
@@ -449,10 +450,9 @@ async def run_agent_task(
 
         # --- 5. Initialize or Update Agent ---
         webui_manager.bu_agent_task_id = str(uuid.uuid4())  # New ID for this task run
-        os.makedirs(
-            os.path.join(save_agent_history_path, webui_manager.bu_agent_task_id),
-            exist_ok=True,
-        )
+        ensure_dir(
+            os.path.join(save_agent_history_path, webui_manager.bu_agent_task_id)
+        )  # // ensure history task dir
         history_file = os.path.join(
             save_agent_history_path,
             webui_manager.bu_agent_task_id,

--- a/src/webui/components/deep_research_agent_tab.py
+++ b/src/webui/components/deep_research_agent_tab.py
@@ -6,6 +6,7 @@ from src.webui.webui_manager import WebuiManager
 from src.utils import config
 import logging
 import os
+from src.utils.utils import ensure_dir  # // import directory helper
 from typing import Any, Dict, AsyncGenerator, Optional, Tuple, Union
 import asyncio
 import json
@@ -62,7 +63,7 @@ async def run_deep_research(webui_manager: WebuiManager, components: Dict[Compon
 
     # Store base save dir for stop handler
     webui_manager.dr_save_dir = base_save_dir
-    os.makedirs(base_save_dir, exist_ok=True)
+    ensure_dir(base_save_dir)  # // ensure base save dir exists
 
     # --- 2. Initial UI Update ---
     yield {

--- a/src/webui/webui_manager.py
+++ b/src/webui/webui_manager.py
@@ -18,6 +18,7 @@ from src.browser.custom_browser import CustomBrowser
 from src.browser.custom_context import CustomBrowserContext
 from src.controller.custom_controller import CustomController
 from src.agent.deep_research.deep_research_agent import DeepResearchAgent
+from src.utils.utils import ensure_dir  # utility to guarantee directories
 
 
 class WebuiManager:
@@ -26,7 +27,7 @@ class WebuiManager:
         self.component_to_id: dict[Component, str] = {}
 
         self.settings_save_dir = settings_save_dir
-        os.makedirs(self.settings_save_dir, exist_ok=True)
+        ensure_dir(self.settings_save_dir)  # // ensure dir exists
 
     def init_browser_use_agent(self) -> None:
         """

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -52,7 +52,7 @@ def test_get_latest_files():  # latest per extension
 
 def test_get_latest_files_missing_dir():  # dir absent handling
     with patch('os.path.exists', return_value=False):  # simulate missing dir
-        with patch('os.makedirs') as mk:  # patch makedirs
+        with patch('src.utils.utils.ensure_dir') as mk:  # patch dir helper
             result = get_latest_files('/missing')  # call util
-            mk.assert_called_once_with('/missing', exist_ok=True)  # ensure called
+            mk.assert_called_once_with('/missing')  # ensure called
     assert result == {'.webm': None, '.zip': None}  # expect empty dict


### PR DESCRIPTION
## Summary
- create `ensure_dir` helper in `utils`
- replace direct `os.makedirs` calls with `ensure_dir`
- update tests to patch new utility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*