### PR TITLE
Fix uuid import removal

### DIFF
--- a/src/webui/webui_manager.py
+++ b/src/webui/webui_manager.py
@@ -6,7 +6,7 @@ import gradio as gr
 from datetime import datetime
 
 from typing import Optional, Dict, List, Any  #(add Any for get_component_value return types)
-import uuid
+# removed unused uuid import  #(removed unused module)
 
 import asyncio
 


### PR DESCRIPTION
## Summary
- remove unused `uuid` import in webui manager

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*