### PR TITLE
Fix duplicate imports in custom browser

### DIFF
--- a/src/browser/custom_browser.py
+++ b/src/browser/custom_browser.py
@@ -9,9 +9,8 @@ from patchright.async_api import (
     async_playwright,
 )
 from browser_use.browser.browser import Browser, IN_DOCKER
-from browser_use.browser.context import BrowserContext, BrowserContextConfig
-from patchright.async_api import BrowserContext as PlaywrightBrowserContext
-import logging
+from browser_use.browser.context import BrowserContext, BrowserContextConfig  # deduped duplicate import
+import logging  # removed extra PlaywrightBrowserContext import
 
 from browser_use.browser.chrome import (
     CHROME_ARGS,
@@ -20,7 +19,6 @@ from browser_use.browser.chrome import (
     CHROME_DOCKER_ARGS,
     CHROME_HEADLESS_ARGS,
 )
-from browser_use.browser.context import BrowserContext, BrowserContextConfig
 from browser_use.browser.utils.screen_resolution import get_screen_resolution, get_window_adjustments
 from browser_use.utils import time_execution_async
 import socket


### PR DESCRIPTION
## Summary
- clean up duplicate context imports in `custom_browser.py`

## Testing
- `python -m py_compile src/browser/custom_browser.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*