### PR TITLE
Add interface and CLI tests

### DIFF
--- a/tests/test_webui_cli.py
+++ b/tests/test_webui_cli.py
@@ -1,0 +1,13 @@
+import importlib.util
+import subprocess
+import sys
+import pytest
+
+skip = importlib.util.find_spec("dotenv") is None or importlib.util.find_spec("gradio") is None
+
+@pytest.mark.skipif(skip, reason="required packages missing")
+def test_webui_help_runs():
+    result = subprocess.run([sys.executable, 'webui.py', '--help'], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert 'usage:' in result.stdout.lower()
+

--- a/tests/webui/test_interface.py
+++ b/tests/webui/test_interface.py
@@ -1,0 +1,12 @@
+import pytest
+
+skip_msg = "gradio is required for this test"
+gr = pytest.importorskip("gradio", reason=skip_msg)
+
+from src.webui.interface import create_ui, theme_map
+
+
+def test_create_ui_returns_blocks_for_each_theme():
+    for name in theme_map:
+        ui = create_ui(theme_name=name)
+        assert isinstance(ui, gr.Blocks)


### PR DESCRIPTION
## Summary
- test `create_ui` returns a `gr.Blocks` for all themes
- ensure `webui.py --help` parses when dependencies are installed

## Testing
- `pytest tests/webui/test_interface.py tests/test_webui_cli.py -q`