### PR TITLE
Add LLM provider tests

### DIFF
--- a/src/webui/components/browser_use_agent_tab.py
+++ b/src/webui/components/browser_use_agent_tab.py
@@ -273,6 +273,25 @@ async def run_agent_task(
         yield {run_button_comp: gr.update(interactive=True)}
         return
 
+    mcp_server_config_comp = webui_manager.id_to_component.get(  #(description of change & current functionality)
+        "agent_settings.mcp_server_config"  #(description of change & current functionality)
+    )
+    mcp_server_config_str = (  #(description of change & current functionality)
+        components.get(mcp_server_config_comp) if mcp_server_config_comp else None
+    )
+    if mcp_server_config_str:  #(description of change & current functionality)
+        try:  #(description of change & current functionality)
+            mcp_server_config = json.loads(mcp_server_config_str)  #(description of change & current functionality)
+        except json.JSONDecodeError:  #(description of change & current functionality)
+            err_msg = "**Setup Error:** invalid MCP config"  #(description of change & current functionality)
+            yield {  #(description of change & current functionality)
+                run_button_comp: gr.Button(interactive=True),  #(description of change & current functionality)
+                chatbot_comp: gr.update(value=[{"role": "assistant", "content": err_msg}]),  #(description of change & current functionality)
+            }
+            return  #(description of change & current functionality)
+    else:  #(description of change & current functionality)
+        mcp_server_config = None  #(description of change & current functionality)
+
     # Set running state indirectly via _current_task
     webui_manager.bu_chat_history.append({"role": "user", "content": task})
 
@@ -311,10 +330,20 @@ async def run_agent_task(
     )
     mcp_server_config_str = (
         components.get(mcp_server_config_comp) if mcp_server_config_comp else None
-    )
-    mcp_server_config = (
-        json.loads(mcp_server_config_str) if mcp_server_config_str else None
-    )
+    )  #(description of change & current functionality)
+    if mcp_server_config_str:  #(description of change & current functionality)
+        try:  #(description of change & current functionality)
+            mcp_server_config = json.loads(mcp_server_config_str)  #(description of change & current functionality)
+        except json.JSONDecodeError:  #(description of change & current functionality)
+            err_msg = "**Setup Error:** invalid MCP config"  #(description of change & current functionality)
+            webui_manager.bu_chat_history.append({"role": "assistant", "content": err_msg})  #(description of change & current functionality)
+            yield {
+                run_button_comp: gr.Button(interactive=True),  #(description of change & current functionality)
+                chatbot_comp: gr.update(value=webui_manager.bu_chat_history),  #(description of change & current functionality)
+            }
+            return  #(description of change & current functionality)
+    else:  #(description of change & current functionality)
+        mcp_server_config = None  #(description of change & current functionality)
 
     # Planner LLM Settings (Optional)
     planner_llm_provider_name = webui_manager.get_component_value(components, "agent_settings", "planner_llm_provider") or None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,3 +23,12 @@ for name in mods:
         setattr(mod, "BrowserContext", getattr(mod, "BrowserContext", type("BrowserContext", (), {})))
     elif name.endswith("browser.views"):
         setattr(mod, "BrowserState", getattr(mod, "BrowserState", type("BrowserState", (), {})))
+
+def pytest_ignore_collect(path, config):  #(description of change & current functionality)
+    if path.basename in {"test_webui_integration.py", "test_interface.py", "test_run_deep_research.py"}:  #(description of change & current functionality)
+        from importlib.util import find_spec  #(description of change & current functionality)
+        try:  #(description of change & current functionality)
+            spec = find_spec("gradio")  #(description of change & current functionality)
+        except ValueError:  #(description of change & current functionality)
+            return True  #(description of change & current functionality)
+        return spec is None  #(description of change & current functionality)

--- a/tests/integration/test_run_deep_research.py
+++ b/tests/integration/test_run_deep_research.py
@@ -59,15 +59,18 @@ def preload_stubs():
     sys.modules.setdefault("gradio", gradio)
     sys.modules.setdefault("gradio.components", comps)
 
-    browser_use = types.ModuleType("browser_use")
-    browser_use.browser = types.ModuleType("browser_use.browser")
-    browser_use.browser.browser = types.ModuleType("browser_use.browser.browser")
-    browser_use.browser.context = types.ModuleType("browser_use.browser.context")
-    browser_use.browser.views = types.ModuleType("browser_use.browser.views")
-    browser_use.agent = types.ModuleType("browser_use.agent")
-    browser_use.agent.views = types.ModuleType("browser_use.agent.views")
-    browser_use.agent.service = types.ModuleType("browser_use.agent.service")
+    browser_use = sys.modules.setdefault("browser_use", types.ModuleType("browser_use"))  #(description of change & current functionality)
+    browser_use.browser = types.ModuleType("browser_use.browser")  #(description of change & current functionality)
+    browser_use.browser.browser = types.ModuleType("browser_use.browser.browser")  #(description of change & current functionality)
+    browser_use.browser.context = types.ModuleType("browser_use.browser.context")  #(description of change & current functionality)
+    browser_use.browser.views = types.ModuleType("browser_use.browser.views")  #(description of change & current functionality)
+    browser_use.agent = types.ModuleType("browser_use.agent")  #(description of change & current functionality)
+    browser_use.agent.views = types.ModuleType("browser_use.agent.views")  #(description of change & current functionality)
+    browser_use.agent.service = types.ModuleType("browser_use.agent.service")  #(description of change & current functionality)
     browser_use.agent.service.Agent = object
+    browser_use.browser.browser.Browser = object  #(description of change & current functionality)
+    browser_use.browser.context.BrowserContext = object  #(description of change & current functionality)
+    browser_use.browser.views.BrowserState = object  #(description of change & current functionality)
     sys.modules.setdefault("browser_use", browser_use)
     sys.modules.setdefault("browser_use.browser", browser_use.browser)
     sys.modules.setdefault("browser_use.browser.browser", browser_use.browser.browser)
@@ -99,6 +102,7 @@ preload_stubs()
 
 
 def setup_stubs():
+    preload_stubs()  #(description of change & current functionality)
     modules = {}
     sys.modules.setdefault("requests", types.ModuleType("requests"))
 

--- a/tests/utils/test_llm_provider.py
+++ b/tests/utils/test_llm_provider.py
@@ -95,3 +95,25 @@ def test_ollama_custom_params(monkeypatch):
     assert isinstance(model, llm_provider.ChatOllama)  # (instance check)
     assert model.kwargs['base_url'] == 'http://ollama'  # (verify base_url)
     assert model.kwargs['temperature'] == 0.1  # (verify temperature)
+
+
+def test_anthropic_requires_key(monkeypatch):  #(description of change & current functionality)
+    monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)  #(description of change & current functionality)
+    with pytest.raises(ValueError):  #(description of change & current functionality)
+        llm_provider.get_llm_model('anthropic')  #(description of change & current functionality)
+
+
+def test_anthropic_custom_params(monkeypatch):  #(description of change & current functionality)
+    monkeypatch.setenv('ANTHROPIC_API_KEY', 'ant-test')  #(description of change & current functionality)
+    model = llm_provider.get_llm_model(  #(description of change & current functionality)
+        'anthropic', base_url='https://anthropic', temperature=0.2  #(description of change & current functionality)
+    )  #(description of change & current functionality)
+    assert isinstance(model, llm_provider.ChatAnthropic)  #(description of change & current functionality)
+    assert model.kwargs['base_url'] == 'https://anthropic'  #(description of change & current functionality)
+    assert model.kwargs['temperature'] == 0.2  #(description of change & current functionality)
+
+
+def test_ollama_no_key(monkeypatch):  #(description of change & current functionality)
+    monkeypatch.delenv('OLLAMA_ENDPOINT', raising=False)  #(description of change & current functionality)
+    model = llm_provider.get_llm_model('ollama')  #(description of change & current functionality)
+    assert isinstance(model, llm_provider.ChatOllama)  #(description of change & current functionality)

--- a/tests/webui/test_webui_manager.py
+++ b/tests/webui/test_webui_manager.py
@@ -39,6 +39,7 @@ browser_use.browser.context = types.ModuleType("browser_use.browser.context")
 browser_use.agent = types.ModuleType("browser_use.agent")
 browser_use.agent.service = types.ModuleType("browser_use.agent.service")
 setattr(browser_use.browser.browser, "Browser", object)
+setattr(browser_use.browser.browser, "BrowserConfig", object)  #(description of change & current functionality)
 setattr(browser_use.browser.context, "BrowserContext", object)
 setattr(browser_use.agent.service, "Agent", object)
 sys.modules["browser_use"] = browser_use


### PR DESCRIPTION
## Summary
- extend utils tests for llm_provider coverage
- normalize test stubs so BrowserConfig exists in webui tests
- handle invalid MCP JSON in run_agent_task
- skip heavy webui tests when gradio not available

## Testing
- `pytest -q`