### PR TITLE
Add docstrings for utilities

### DIFF
--- a/src/utils/browser_cleanup.py
+++ b/src/utils/browser_cleanup.py
@@ -50,6 +50,7 @@ logger = logging.getLogger(__name__)
 
 # Async function to close browser resources (context and browser)
 async def close_browser_resources(browser, context):
+    """Safely close Playwright context and browser objects."""  # docstring added explaining function use
     # Check if a browser context is provided
     if context:
         # Log the closing of the browser context
@@ -72,4 +73,4 @@ async def close_browser_resources(browser, context):
         except Exception as e:
             # Log the error if closing the browser fails
             logger.error(f"Error closing browser: {e}")
-`
+

--- a/src/utils/browser_launch.py
+++ b/src/utils/browser_launch.py
@@ -66,11 +66,17 @@ logger = logging.getLogger(__name__)
 
 
 def build_browser_launch_options(config: Dict[str, Any]) -> Tuple[Optional[str], List[str]]:  # build browser options
-    """Build browser binary path and extra launch arguments."""  # function description
-    window_w = config.get("window_width", 1280)  # width from config
-    window_h = config.get("window_height", 1100)  # height from config
-    extra_args = [f"--window-size={window_w},{window_h}"]  # default arg list
-    browser_user_data_dir = config.get("user_data_dir", None)  # custom data dir
+    """Build browser binary path and extra launch arguments.
+
+    The ``config`` dict may include ``window_width``, ``window_height``,
+    ``user_data_dir``, ``use_own_browser`` and ``browser_binary_path``.
+    Environment variables ``CHROME_PATH`` and ``CHROME_USER_DATA`` override
+    path settings when ``use_own_browser`` is true.
+    """  # function description expanded
+    window_w = config.get("window_width", 1280)  # width from config; default 1280
+    window_h = config.get("window_height", 1100)  # height from config; default 1100
+    extra_args = [f"--window-size={window_w},{window_h}"]  # window geometry arg
+    browser_user_data_dir = config.get("user_data_dir", None)  # custom data dir for persistent profiles
     if browser_user_data_dir:
         extra_args.append(f"--user-data-dir={browser_user_data_dir}")  # add dir option
     use_own_browser = config.get("use_own_browser", False)  # check custom browser usage

--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -1,8 +1,10 @@
+"""Utility helpers for loading configuration files safely."""  # module docstring explaining purpose
 import json, logging, os  # new utility imports for safe json loading
 logger = logging.getLogger(__name__)  # logger setup for this module
 
 
 def load_json_safe(path: str):  # utility to safely load json
+    """Load a JSON file and return ``None`` on failure."""  # docstring describing edge cases
     if not path or not os.path.exists(path):  # validate path exists
         return None  # return None if invalid
     try:
@@ -14,6 +16,7 @@ def load_json_safe(path: str):  # utility to safely load json
 
 
 def load_mcp_server_config(path: str, logger) -> dict | None:  # load MCP server config with validation
+    """Load MCP server JSON returning ``None`` when the file is invalid."""  # docstring describing function
     if not path or not os.path.exists(path) or not path.endswith('.json'):  # validate path exists and is json
         logger.warning(f"{path} is not a valid MCP file.")  # warn when invalid
         return None  # return None on invalid path
@@ -21,3 +24,4 @@ def load_mcp_server_config(path: str, logger) -> dict | None:  # load MCP server
     if data is None:  # check load failure
         logger.warning(f"{path} cannot be loaded.")  # warn when loading fails
     return data  # return parsed json or None
+

--- a/src/utils/llm_provider.py
+++ b/src/utils/llm_provider.py
@@ -112,6 +112,7 @@ logger = logging.getLogger(__name__)
 
 
 class DeepSeekR1ChatOpenAI(ChatOpenAI):
+    """OpenAI client wrapper returning reasoning content alongside text."""  # class docstring
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -174,6 +175,7 @@ class DeepSeekR1ChatOpenAI(ChatOpenAI):
 
 
 class DeepSeekR1ChatOllama(ChatOllama):
+    """Ollama wrapper that splits reasoning tags from final content."""  # class docstring
 
     async def ainvoke(
             self,
@@ -242,6 +244,7 @@ def get_llm_model(provider: str, **kwargs):
     - API keys are sourced from environment variables first for security
     - Explicit API key parameter allows testing but should be used carefully
     - No API keys are logged or exposed in error messages
+    - Environment variable naming uses ``<PROVIDER>_API_KEY`` for consistency
     """
 
     # Handle API key authentication for most providers

--- a/src/utils/mcp_client.py
+++ b/src/utils/mcp_client.py
@@ -84,15 +84,12 @@ logger = logging.getLogger(__name__)
 
 
 async def setup_mcp_client_and_tools(mcp_server_config: Dict[str, Any]) -> Optional[MultiServerMCPClient]:
-    """
-    Initializes the MultiServerMCPClient, connects to servers, fetches tools,
-    filters them, and returns a flat list of usable tools and the client instance.
+    """Initialize MCP client and return the connected instance.
 
-    Returns:
-        A tuple containing:
-        - list[BaseTool]: The filtered list of usable LangChain tools.
-        - MultiServerMCPClient | None: The initialized and started client instance, or None on failure.
-    """
+    The configuration may contain a ``mcpServers`` key describing multiple
+    endpoints. The client is started asynchronously and ``None`` is returned if
+    connection fails.
+    """  # expanded docstring
 
     logger.info("Initializing MultiServerMCPClient...")
 
@@ -113,7 +110,7 @@ async def setup_mcp_client_and_tools(mcp_server_config: Dict[str, Any]) -> Optio
 
 
 def create_tool_param_model(tool: BaseTool) -> Type[BaseModel]:
-    """Creates a Pydantic model from a LangChain tool's schema"""
+    """Generate a Pydantic model matching the given tool schema."""  # expanded docstring
 
     # Get tool schema information
     json_schema = tool.args_schema
@@ -201,7 +198,7 @@ def create_tool_param_model(tool: BaseTool) -> Type[BaseModel]:
 
 
 def resolve_type(prop_details: Dict[str, Any], prefix: str = "") -> Any:
-    """Recursively resolves JSON schema type to Python/Pydantic type"""
+    """Convert JSON schema entries to appropriate Python types."""  # expanded docstring
 
     # Handle reference types
     if '$ref' in prop_details:

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -76,19 +76,26 @@ import uuid
 
 
 def ensure_dir(path: str):
-    os.makedirs(path, exist_ok=True)  # create directory if missing
+    """Create the directory if it does not already exist."""  # added short docstring describing function
+    os.makedirs(path, exist_ok=True)  # create directory if missing; exist_ok handles race conditions
 
 
 def encode_image(img_path):
+    """Return base64 string for an image path or ``None`` when missing."""  # added docstring explaining return
     if not img_path:
         return None
-    with open(img_path, "rb") as fin:
-        image_data = base64.b64encode(fin.read()).decode("utf-8")
+    with open(img_path, "rb") as fin:  # open as binary for encoding
+        image_data = base64.b64encode(fin.read()).decode("utf-8")  # convert to base64 string
     return image_data
 
 
 def get_latest_files(directory: str, file_types: list = ['.webm', '.zip']) -> Dict[str, Optional[str]]:
-    """Get the latest recording and trace files"""
+    """Return mapping of extensions to the most recent file path in ``directory``.
+
+    This helps the UI quickly access newly created recording or trace files.
+    Missing directories are automatically created and the mapping values remain
+    ``None`` when no files are found.
+    """  # expanded docstring for usage
     latest_files: Dict[str, Optional[str]] = {ext: None for ext in file_types}
 
     if not os.path.exists(directory):
@@ -97,13 +104,13 @@ def get_latest_files(directory: str, file_types: list = ['.webm', '.zip']) -> Di
 
     for file_type in file_types:
         try:
-            matches = list(Path(directory).rglob(f"*{file_type}"))
+            matches = list(Path(directory).rglob(f"*{file_type}"))  # gather matching files
             if matches:
                 latest = max(matches, key=lambda p: p.stat().st_mtime)
                 # Only return files that are complete (not being written)
                 if time.time() - latest.stat().st_mtime > 1.0:
                     latest_files[file_type] = str(latest)
         except Exception as e:
-            print(f"Error getting latest {file_type} file: {e}")
+            print(f"Error getting latest {file_type} file: {e}")  # log but continue on error
 
-    return latest_files
+    return latest_files  # mapping of extension -> path or None


### PR DESCRIPTION
## Summary
- document utility functions in `src/utils`
- explain how browser launch options work
- clarify browser cleanup logic
- document safe JSON helpers
- document LLM provider wrappers
- expand Model Context Protocol client docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil', ModuleNotFoundError: No module named 'playwright', SyntaxError in imported modules)*