### PR TITLE
Improve WebUI comments

### DIFF
--- a/src/webui/components/__init__.py
+++ b/src/webui/components/__init__.py
@@ -1,0 +1,1 @@
+"""Container package for UI tab component definitions."""  # (describe package purpose)

--- a/src/webui/components/agent_settings_tab.py
+++ b/src/webui/components/agent_settings_tab.py
@@ -97,7 +97,7 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
     input_components = set(webui_manager.get_components())
     tab_components = {}
 
-    with gr.Row():
+    with gr.Row():  # two columns to keep system prompt inputs aligned
         with gr.Column(scale=1):
             override_system_prompt = gr.Textbox(label="Override system prompt", lines=4, interactive=True)
         with gr.Column(scale=1):
@@ -299,36 +299,36 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
         mcp_json_file=mcp_json_file,
         mcp_server_config=mcp_server_config,
     ))
-    webui_manager.add_components("agent_settings", tab_components)
+    webui_manager.add_components("agent_settings", tab_components)  # register for centralized state tracking
 
     llm_provider.change(
-        fn=lambda x: gr.update(visible=x == "ollama"),
+        fn=lambda x: gr.update(visible=x == "ollama"),  # show context field only when using Ollama
         inputs=llm_provider,
         outputs=ollama_num_ctx
     )
     llm_provider.change(
-        lambda provider: update_model_dropdown(provider),
+        lambda provider: update_model_dropdown(provider),  # populate model list when provider changes
         inputs=[llm_provider],
         outputs=[llm_model_name]
     )
     planner_llm_provider.change(
-        fn=lambda x: gr.update(visible=x == "ollama"),
+        fn=lambda x: gr.update(visible=x == "ollama"),  # planner context size only relevant for Ollama
         inputs=[planner_llm_provider],
         outputs=[planner_ollama_num_ctx]
     )
     planner_llm_provider.change(
-        lambda provider: update_model_dropdown(provider),
+        lambda provider: update_model_dropdown(provider),  # update planner model dropdown
         inputs=[planner_llm_provider],
         outputs=[planner_llm_model_name]
     )
 
     async def update_wrapper(mcp_file):
-        """Wrapper for handle_pause_resume."""
+        """Wrapper for handle_pause_resume."""  # retains async signature for event handler
         update_dict = await update_mcp_server(mcp_file, webui_manager)
         yield update_dict
 
     mcp_json_file.change(
-        update_wrapper,
+        update_wrapper,  # refresh textbox when user selects a new MCP file
         inputs=[mcp_json_file],
         outputs=[mcp_server_config, mcp_server_config]
     )

--- a/src/webui/components/browser_settings_tab.py
+++ b/src/webui/components/browser_settings_tab.py
@@ -95,7 +95,7 @@ def create_browser_settings_tab(webui_manager: WebuiManager):
     input_components = set(webui_manager.get_components())
     tab_components = {}
 
-    with gr.Group():
+    with gr.Group():  # group path settings separately for clarity
         with gr.Row():
             browser_binary_path = gr.Textbox(
                 label="Browser Binary Path",
@@ -207,13 +207,13 @@ def create_browser_settings_tab(webui_manager: WebuiManager):
             window_w=window_w,
         )
     )
-    webui_manager.add_components("browser_settings", tab_components)
+    webui_manager.add_components("browser_settings", tab_components)  # register for persistence and callbacks
 
     async def close_wrapper():
-        """Wrapper for handle_clear."""
+        """Wrapper for handle_clear."""  # called when toggles affecting browser are changed
         await close_browser(webui_manager)
 
-    headless.change(close_wrapper)
-    keep_browser_open.change(close_wrapper)
-    disable_security.change(close_wrapper)
-    use_own_browser.change(close_wrapper)
+    headless.change(close_wrapper)  # closing browser ensures new setting takes effect
+    keep_browser_open.change(close_wrapper)  # allow toggling without stale instance
+    disable_security.change(close_wrapper)  # update security flags immediately
+    use_own_browser.change(close_wrapper)  # handle switching between local/managed browser

--- a/src/webui/components/browser_use_agent_tab.py
+++ b/src/webui/components/browser_use_agent_tab.py
@@ -376,7 +376,7 @@ async def _ask_assistant_callback(
 
 async def run_agent_task(
     webui_manager: WebuiManager, components: Dict[gr.components.Component, Any]
-) -> AsyncGenerator[Dict[gr.components.Component, Any], None]:
+) -> AsyncGenerator[Dict[gr.components.Component, Any], None]:  # used as callback for Run button, yields UI updates
     """Handles the entire lifecycle of initializing and running the agent.
 
     This asynchronous generator function manages the complete execution cycle of the
@@ -560,12 +560,12 @@ async def run_agent_task(
     # Pass the webui_manager instance to the callback when wrapping it
     async def ask_callback_wrapper(
         query: str, browser_context: BrowserContext
-    ) -> Dict[str, Any]:
+    ) -> Dict[str, Any]:  # thin wrapper to inject manager instance
         return await _ask_assistant_callback(webui_manager, query, browser_context)
 
     if not webui_manager.bu_controller:
         webui_manager.bu_controller = CustomController(
-            ask_assistant_callback=ask_callback_wrapper
+            ask_assistant_callback=ask_callback_wrapper  # controller uses wrapper for user prompts
         )
         await webui_manager.bu_controller.setup_mcp_client(mcp_server_config)
 

--- a/src/webui/components/deep_research_agent_tab.py
+++ b/src/webui/components/deep_research_agent_tab.py
@@ -354,7 +354,7 @@ def create_deep_research_agent_tab(webui_manager: WebuiManager):
     input_components = set(webui_manager.get_components())
     tab_components = {}
 
-    with gr.Group():
+    with gr.Group():  # file selection separate from rest of form
         with gr.Row():
             mcp_json_file = gr.File(label="MCP server json", interactive=True, file_types=[".json"])
             mcp_server_config = gr.Textbox(label="MCP server", lines=6, interactive=True, visible=False)
@@ -392,16 +392,16 @@ def create_deep_research_agent_tab(webui_manager: WebuiManager):
             mcp_server_config=mcp_server_config,
         )
     )
-    webui_manager.add_components("deep_research_agent", tab_components)
+    webui_manager.add_components("deep_research_agent", tab_components)  # register components for manager lookups
     webui_manager.init_deep_research_agent()
 
     async def update_wrapper(mcp_file):
-        """Wrapper for handle_pause_resume."""
+        """Wrapper for handle_pause_resume."""  # processes MCP file selection
         update_dict = await update_mcp_server(mcp_file, webui_manager)
         yield update_dict
 
     mcp_json_file.change(
-        update_wrapper,
+        update_wrapper,  # refresh server config textbox
         inputs=[mcp_json_file],
         outputs=[mcp_server_config, mcp_server_config]
     )
@@ -410,23 +410,23 @@ def create_deep_research_agent_tab(webui_manager: WebuiManager):
     all_managed_inputs = set(webui_manager.get_components())
 
     # --- Define Event Handler Wrappers ---
-    async def start_wrapper(comps: Dict[Component, Any]) -> AsyncGenerator[Dict[Component, Any], None]:
+    async def start_wrapper(comps: Dict[Component, Any]) -> AsyncGenerator[Dict[Component, Any], None]:  # relay start button event
         async for update in run_deep_research(webui_manager, comps):
             yield update
 
-    async def stop_wrapper() -> AsyncGenerator[Dict[Component, Any], None]:
+    async def stop_wrapper() -> AsyncGenerator[Dict[Component, Any], None]:  # relay stop button event
         update_dict = await stop_deep_research(webui_manager)
         yield update_dict
 
     # --- Connect Handlers ---
     start_button.click(
-        fn=start_wrapper,
+        fn=start_wrapper,  # start research with current UI values
         inputs=all_managed_inputs,
         outputs=dr_tab_outputs
     )
 
     stop_button.click(
-        fn=stop_wrapper,
+        fn=stop_wrapper,  # stop ongoing research task
         inputs=None,
         outputs=dr_tab_outputs
     )

--- a/src/webui/components/load_save_config_tab.py
+++ b/src/webui/components/load_save_config_tab.py
@@ -103,7 +103,7 @@ def create_load_save_config_tab(webui_manager: WebuiManager):
                 interactive=True
             )
         with gr.Column(scale=1):
-            with gr.Row():
+            with gr.Row():  # keep load/save buttons side by side for usability
                 load_config_button = gr.Button("Load Config", variant="primary")
                 save_config_button = gr.Button("Save UI Settings", variant="primary")
 
@@ -120,16 +120,16 @@ def create_load_save_config_tab(webui_manager: WebuiManager):
         config_file=config_file,
     ))
 
-    webui_manager.add_components("load_save_config", tab_components)
+    webui_manager.add_components("load_save_config", tab_components)  # register load/save widgets for persistence
 
     save_config_button.click(
-        fn=webui_manager.save_config,
+        fn=webui_manager.save_config,  # persist current settings to file
         inputs=set(webui_manager.get_components()),
         outputs=[config_status]
     )
 
     load_config_button.click(
-        fn=webui_manager.load_config,
+        fn=webui_manager.load_config,  # restore settings from selected file
         inputs=[config_file],
         outputs=webui_manager.get_components(),
     )

--- a/src/webui/webui_manager.py
+++ b/src/webui/webui_manager.py
@@ -1,5 +1,5 @@
 
-```python
+# ```python  #(convert stray markup to comment for valid syntax)
 """
 WebUI Manager - Central State and Component Management
 
@@ -226,8 +226,8 @@ class WebuiManager:
             comp_id = f"{tab_name}.{comp_name}"
             
             # Establish bidirectional mapping for efficient access
-            self.id_to_component[comp_id] = component
-            self.component_to_id[component] = comp_id
+            self.id_to_component[comp_id] = component  # map ID to component for later lookup
+            self.component_to_id[component] = comp_id  # reverse map for event handling
 
     def get_components(self) -> list["Component"]:
         """
@@ -433,7 +433,7 @@ class WebuiManager:
         - Directory guarantee: ensure_dir() in __init__ prevents save failures
         """
         # Dictionary to store component states that should be persisted
-        cur_settings = {}
+        cur_settings = {}  # store user-provided values for JSON persistence
         
         for comp in components:
             # Filter out components that shouldn't be saved
@@ -506,7 +506,7 @@ class WebuiManager:
             ui_settings = json.load(fr)
 
         # Dictionary to accumulate component updates for Gradio
-        update_components = {}
+        update_components = {}  # collect per-component updates to return to Gradio
         
         # Process each saved component setting
         for comp_id, comp_val in ui_settings.items():
@@ -531,4 +531,4 @@ class WebuiManager:
         
         # Yield the component updates for Gradio to apply
         yield update_components
-```
+# ```  #(convert stray markup to comment for valid syntax)


### PR DESCRIPTION
## Summary
- clarify stray markup in `webui_manager.py`
- explain how components register to the manager and persist settings
- add inline notes for Gradio callbacks in agent settings tab
- document browser settings callbacks and grouping
- annotate Browser Use and Deep Research agent logic
- explain layout decisions in config tab
- add package comment to components package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright' and SyntaxErrors)*