### PR TITLE
Add psutil and playwright dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Install Python packages:
 ```bash
 uv pip install -r requirements.txt
 ```
+This installs all required packages, including `psutil` for process management and `playwright` for browser automation.
 
 Install Browsers in Playwright:
 You can install specific browsers by running:
@@ -227,6 +228,7 @@ CHROME_PERSISTENT_SESSION=true docker compose up --build
    ```bash
    uv pip install -r requirements.txt
    ```
+   # psutil and playwright are installed from requirements.txt for tests
 2. Install test specific packages:
    ```bash
    uv pip install -r tests/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ langchain_mcp_adapters==0.0.9
 langgraph==0.3.34
 langchain-community
 python-dotenv
+psutil  # Process management utilities
+playwright  # Browser automation framework


### PR DESCRIPTION
## Summary
- include psutil and playwright in requirements.txt
- note the new dependencies in the installation guide and test instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*