### PR TITLE
Add package docstrings

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,4 @@
+"""Top-level package initialization for Browser Use application."""  # module docstring describing package purpose
 try:
     from .webui import webui_manager  # (expose webui manager for tests)
 except Exception:

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -1,0 +1,1 @@
+"""Agent package with browser automation implementations."""  # module docstring summarizing package

--- a/src/browser/__init__.py
+++ b/src/browser/__init__.py
@@ -1,0 +1,1 @@
+"""Browser package exposing custom automation classes."""  # module docstring for package overview

--- a/src/browser/custom_browser.py
+++ b/src/browser/custom_browser.py
@@ -1,3 +1,4 @@
+"""Custom browser implementation with enhanced setup."""  # module docstring summarizing purpose
 import asyncio
 
 from patchright.async_api import Browser as PlaywrightBrowser

--- a/src/browser/custom_context.py
+++ b/src/browser/custom_context.py
@@ -1,3 +1,4 @@
+"""Custom browser context providing anti-detection features."""  # module docstring summarizing purpose
 import json
 import logging
 import os

--- a/src/controller/__init__.py
+++ b/src/controller/__init__.py
@@ -1,0 +1,1 @@
+"""Controller package exposing custom control logic."""  # module docstring summary

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers shared across the Browser Use project."""  # module docstring describing utilities

--- a/src/webui/__init__.py
+++ b/src/webui/__init__.py
@@ -1,3 +1,4 @@
+"""Expose WebUI manager when dependencies are available."""  # module docstring explaining conditional import
 try:
     from . import webui_manager  # (expose manager module)
 except Exception:


### PR DESCRIPTION
## Summary
- document the package modules with top level docstrings
- add module explanations in custom browser files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for psutil and playwright)*