### PR TITLE
Fix GIF path assignment

### DIFF
--- a/src/webui/components/browser_use_agent_tab.py
+++ b/src/webui/components/browser_use_agent_tab.py
@@ -639,4 +639,9 @@ async def run_agent_task(
         gif_path = os.path.join(
             save_agent_history_path,
             webui_manager.bu_agent_task_id,
-            f"{webui_manager.bu_agent_task_id}.gif",\n{type(e).__name__}: {e}\n
+            f"{webui_manager.bu_agent_task_id}.gif",
+        )  # // path for generated GIF
+
+    except Exception as e:  # // capture any setup errors
+        logger.error(f"run_agent_task encountered error: {e}", exc_info=True)
+        return


### PR DESCRIPTION
## Summary
- close `gif_path` assignment in Browser Use Agent tab
- add fallback exception handling so the module compiles

## Testing
- `python -m py_compile src/webui/components/browser_use_agent_tab.py`
- `python -m py_compile $(git ls-files '*.py')` *(fails: IndentationError in agent_settings_tab.py)*
- `pytest --maxfail=1 -q` *(fails: ModuleNotFoundError: playwright)*