### PR TITLE
Improve startup comments

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-# Start supervisord in the foreground to properly manage child processes
-exec /usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf
+# Start supervisord in the foreground so Docker can monitor it    # ensures container shuts down cleanly when supervisord exits
+exec /usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf    # launch supervisor with provided config

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,96 +1,96 @@
 [supervisord]
-user=root
-nodaemon=true
-logfile=/dev/stdout
-logfile_maxbytes=0
-loglevel=debug
+user=root                                        ; run supervisor as root to manage child processes
+nodaemon=true                                    ; keep supervisor in foreground so container detects failures
+logfile=/dev/stdout                              ; send logs to Docker stdout for easy viewing
+logfile_maxbytes=0                               ; disable logfile rotation for stdout
+loglevel=debug                                   ; verbose logging helps with debugging
 
 [program:xvfb]
-command=Xvfb :99 -screen 0 %(ENV_RESOLUTION)s -ac +extension GLX +render -noreset
-autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-priority=100
-startsecs=3
-stopsignal=TERM
-stopwaitsecs=10
+command=Xvfb :99 -screen 0 %(ENV_RESOLUTION)s -ac +extension GLX +render -noreset    ; virtual display for headless Chrome
+autorestart=true                                  ; restart Xvfb if it stops
+stdout_logfile=/dev/stdout                        ; log to stdout
+stdout_logfile_maxbytes=0                         ; no log rotation
+stderr_logfile=/dev/stderr                        ; log errors to stderr
+stderr_logfile_maxbytes=0                         ; no log rotation
+priority=100                                      ; start early since others depend on display
+startsecs=3                                       ; give Xvfb time to initialize
+stopsignal=TERM                                   ; use TERM to stop gracefully
+stopwaitsecs=10                                   ; wait 10 seconds before force kill
 
 [program:vnc_setup]
-command=bash -c "mkdir -p ~/.vnc && echo '%(ENV_VNC_PASSWORD)s' | vncpasswd -f > ~/.vnc/passwd && chmod 600 ~/.vnc/passwd && ls -la ~/.vnc/passwd"
-autorestart=false
-startsecs=0
-priority=150
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
+command=bash -c "mkdir -p ~/.vnc && echo '%(ENV_VNC_PASSWORD)s' | vncpasswd -f > ~/.vnc/passwd && chmod 600 ~/.vnc/passwd && ls -la ~/.vnc/passwd"    ; prepare VNC password
+autorestart=false                                   ; runs once to set credentials
+startsecs=0                                         ; no wait needed
+priority=150                                        ; run after Xvfb
+stdout_logfile=/dev/stdout                          ; log to stdout
+stdout_logfile_maxbytes=0                           ; no log rotation
+stderr_logfile=/dev/stderr                          ; log errors to stderr
+stderr_logfile_maxbytes=0                           ; no log rotation
 
 [program:x11vnc]
-command=bash -c "mkdir -p /var/log && touch /var/log/x11vnc.log && chmod 666 /var/log/x11vnc.log && sleep 5 && DISPLAY=:99 x11vnc -display :99 -forever -shared -rfbauth /root/.vnc/passwd -rfbport 5901 -o /var/log/x11vnc.log"
-autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-priority=200
-startretries=10
-startsecs=10
-stopsignal=TERM
-stopwaitsecs=10
-depends_on=vnc_setup,xvfb
+command=bash -c "mkdir -p /var/log && touch /var/log/x11vnc.log && chmod 666 /var/log/x11vnc.log && sleep 5 && DISPLAY=:99 x11vnc -display :99 -forever -shared -rfbauth /root/.vnc/passwd -rfbport 5901 -o /var/log/x11vnc.log"    ; expose the virtual display over VNC
+autorestart=true                                     ; keep VNC server running
+stdout_logfile=/dev/stdout                           ; log to stdout
+stdout_logfile_maxbytes=0                            ; no log rotation
+stderr_logfile=/dev/stderr                           ; log errors to stderr
+stderr_logfile_maxbytes=0                            ; no log rotation
+priority=200                                         ; start after VNC password is set
+startretries=10                                      ; retry startup if VNC server fails
+startsecs=10                                         ; wait for server to be ready
+stopsignal=TERM                                      ; gracefully stop on TERM
+stopwaitsecs=10                                      ; wait 10 seconds for stop
+depends_on=vnc_setup,xvfb                            ; requires Xvfb and password setup
 
 [program:x11vnc_log]
-command=bash -c "mkdir -p /var/log && touch /var/log/x11vnc.log && tail -f /var/log/x11vnc.log"
-autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-priority=250
-stopsignal=TERM
-stopwaitsecs=5
-depends_on=x11vnc
+command=bash -c "mkdir -p /var/log && touch /var/log/x11vnc.log && tail -f /var/log/x11vnc.log"    ; stream VNC server logs
+autorestart=true                                     ; keep tail running
+stdout_logfile=/dev/stdout                           ; log to stdout
+stdout_logfile_maxbytes=0                            ; no log rotation
+stderr_logfile=/dev/stderr                           ; log errors to stderr
+stderr_logfile_maxbytes=0                            ; no log rotation
+priority=250                                         ; run after VNC server
+stopsignal=TERM                                      ; stop with TERM
+stopwaitsecs=5                                       ; short wait on stop
+depends_on=x11vnc                                    ; only start if VNC server is up
 
 [program:novnc]
-command=bash -c "sleep 5 && cd /opt/novnc && ./utils/novnc_proxy --vnc localhost:5901 --listen 0.0.0.0:6080 --web /opt/novnc"
-autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-priority=300
-startretries=5
-startsecs=3
-depends_on=x11vnc
+command=bash -c "sleep 5 && cd /opt/novnc && ./utils/novnc_proxy --vnc localhost:5901 --listen 0.0.0.0:6080 --web /opt/novnc"    ; web-based VNC client
+autorestart=true                                     ; keep NoVNC available
+stdout_logfile=/dev/stdout                           ; log to stdout
+stdout_logfile_maxbytes=0                            ; no log rotation
+stderr_logfile=/dev/stderr                           ; log errors to stderr
+stderr_logfile_maxbytes=0                            ; no log rotation
+priority=300                                         ; start after VNC server
+startretries=5                                       ; retry if NoVNC fails
+startsecs=3                                          ; short wait for startup
+depends_on=x11vnc                                    ; requires VNC server
 
 [program:persistent_browser]
-environment=START_URL="data:text/html,<html><body><h1>Browser Ready</h1></body></html>"
-command=bash -c "mkdir -p /app/data/chrome_data && sleep 8 && $(find /ms-playwright/chromium-*/chrome-linux -name chrome) --user-data-dir=/app/data/chrome_data --window-position=0,0 --window-size=%(ENV_RESOLUTION_WIDTH)s,%(ENV_RESOLUTION_HEIGHT)s --start-maximized --no-sandbox --disable-dev-shm-usage --disable-gpu --disable-software-rasterizer --disable-setuid-sandbox --no-first-run --no-default-browser-check --no-experiments --ignore-certificate-errors --remote-debugging-port=9222 --remote-debugging-address=0.0.0.0 \"$START_URL\""
-autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-priority=350
-startretries=5
-startsecs=10
-stopsignal=TERM
-stopwaitsecs=15
-depends_on=novnc
+environment=START_URL="data:text/html,<html><body><h1>Browser Ready</h1></body></html>"    ; simple page so Chrome starts without an external site
+command=bash -c "mkdir -p /app/data/chrome_data && sleep 8 && $(find /ms-playwright/chromium-*/chrome-linux -name chrome) --user-data-dir=/app/data/chrome_data --window-position=0,0 --window-size=%(ENV_RESOLUTION_WIDTH)s,%(ENV_RESOLUTION_HEIGHT)s --start-maximized --no-sandbox --disable-dev-shm-usage --disable-gpu --disable-software-rasterizer --disable-setuid-sandbox --no-first-run --no-default-browser-check --no-experiments --ignore-certificate-errors --remote-debugging-port=9222 --remote-debugging-address=0.0.0.0 \"$START_URL\""    ; persistent Chrome session for the UI
+autorestart=true                                     ; restart browser if closed
+stdout_logfile=/dev/stdout                           ; log to stdout
+stdout_logfile_maxbytes=0                            ; no log rotation
+stderr_logfile=/dev/stderr                           ; log errors to stderr
+stderr_logfile_maxbytes=0                            ; no log rotation
+priority=350                                         ; run after NoVNC so UI is ready
+startretries=5                                       ; retry a few times on failure
+startsecs=10                                         ; allow Chrome to fully start
+stopsignal=TERM                                      ; gracefully stop on TERM
+stopwaitsecs=15                                      ; wait longer since browser may take time
+depends_on=novnc                                     ; requires NoVNC for remote view
 
 [program:webui]
-command=python webui.py --ip 0.0.0.0 --port 7788
-directory=/app
-autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-priority=400
-startretries=3
-startsecs=3
-stopsignal=TERM
-stopwaitsecs=10
-depends_on=persistent_browser
+command=python webui.py --ip 0.0.0.0 --port 7788                         ; start the gradio interface
+directory=/app                                                          ; run from project root
+autorestart=true                                                        ; keep the web UI up
+stdout_logfile=/dev/stdout                                              ; log to stdout
+stdout_logfile_maxbytes=0                                               ; no log rotation
+stderr_logfile=/dev/stderr                                              ; log errors to stderr
+stderr_logfile_maxbytes=0                                               ; no log rotation
+priority=400                                                            ; start last after browser
+startretries=3                                                          ; attempt a few restarts if needed
+startsecs=3                                                             ; wait for startup
+stopsignal=TERM                                                         ; gracefully stop on TERM
+stopwaitsecs=10                                                         ; wait 10 seconds for shutdown
+depends_on=persistent_browser                                           ; requires browser ready


### PR DESCRIPTION
## Summary
- clarify why supervisord is foregrounded in entrypoint.sh
- document each supervisor program in `supervisord.conf`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*