### PR TITLE
Add docstrings to tests

### DIFF
--- a/tests/agent/test_browser_use_agent.py
+++ b/tests/agent/test_browser_use_agent.py
@@ -121,7 +121,9 @@ def setup_stubs():
     return modules.keys()
 
 
-def test_run_stops_when_done(monkeypatch):  # agent exits loop when done flag set
+def test_run_stops_when_done(monkeypatch):
+    """Agent loop exits when history indicates completion."""  #(added docstring summarizing test intent)
+    # agent exits loop when done flag set
     mods = setup_stubs()
     import importlib.util, os
     path = os.path.join(os.path.dirname(__file__), '..', '..', 'src', 'agent', 'browser_use', 'browser_use_agent.py')
@@ -142,7 +144,9 @@ def test_run_stops_when_done(monkeypatch):  # agent exits loop when done flag se
         sys.modules.pop(m, None)
 
 
-def test_keyboard_interrupt(monkeypatch):  # graceful exit on KeyboardInterrupt
+def test_keyboard_interrupt(monkeypatch):
+    """Gracefully exit when KeyboardInterrupt is raised."""  #(added docstring summarizing test intent)
+    # graceful exit on KeyboardInterrupt
     mods = setup_stubs()
     import importlib.util, os
     path = os.path.join(os.path.dirname(__file__), '..', '..', 'src', 'agent', 'browser_use', 'browser_use_agent.py')

--- a/tests/agent/test_deep_research_agent.py
+++ b/tests/agent/test_deep_research_agent.py
@@ -80,7 +80,9 @@ def setup_stubs():
 setup_stubs()
 from src.agent.deep_research import deep_research_agent as dr
 
-def test_run_browser_search_tool(monkeypatch):  # run tasks in parallel browsers
+def test_run_browser_search_tool(monkeypatch):
+    """Run search queries across parallel browsers and collect results."""  #(added docstring summarizing test intent)
+    # run tasks in parallel browsers
     async def fake_task(query, task_id, llm, browser_config, stop_event):
         return {'query': query, 'result': f'result_{query}', 'status': 'completed'}
     monkeypatch.setattr(dr, 'run_single_browser_task', fake_task)
@@ -91,7 +93,9 @@ def test_run_browser_search_tool(monkeypatch):  # run tasks in parallel browsers
         {'query': 'q2', 'result': 'result_q2', 'status': 'completed'},
     ]
 
-def test_run_browser_search_tool_cancel(monkeypatch):  # cancellation yields cancelled status
+def test_run_browser_search_tool_cancel(monkeypatch):
+    """Cancellation event short-circuits browser search tool."""  #(added docstring summarizing test intent)
+    # cancellation yields cancelled status
     called = False
     async def fake_task(*a, **k):
         nonlocal called
@@ -103,7 +107,9 @@ def test_run_browser_search_tool_cancel(monkeypatch):  # cancellation yields can
     assert not called
     assert res == [{'query': 'q1', 'result': None, 'status': 'cancelled'}]
 
-def test_create_browser_search_tool(monkeypatch):  # create StructuredTool wrapper
+def test_create_browser_search_tool(monkeypatch):
+    """Build a StructuredTool wrapper around the search runner."""  #(added docstring summarizing test intent)
+    # create StructuredTool wrapper
     async def fake_runner(queries, task_id, llm, browser_config, stop_event, max_parallel_browsers=1):
         return ['ok', queries, task_id, llm, browser_config, stop_event, max_parallel_browsers]
     monkeypatch.setattr(dr, '_run_browser_search_tool', fake_runner)
@@ -120,7 +126,9 @@ def test_create_browser_search_tool(monkeypatch):  # create StructuredTool wrapp
     assert result[6] == 3
 
 
-def test_load_previous_state(tmp_path):  # load saved state from files
+def test_load_previous_state(tmp_path):
+    """Read research plan and search results from disk."""  #(added docstring summarizing test intent)
+    # load saved state from files
     plan = tmp_path / dr.PLAN_FILENAME
     plan.write_text('- [x] done\n- [ ] todo\n')
     search = tmp_path / dr.SEARCH_INFO_FILENAME
@@ -132,13 +140,17 @@ def test_load_previous_state(tmp_path):  # load saved state from files
     assert len(state['research_plan']) == 2
 
 
-def test_save_report_to_md(tmp_path):  # write markdown report file
+def test_save_report_to_md(tmp_path):
+    """Persist markdown report to disk."""  #(added docstring summarizing test intent)
+    # write markdown report file
     dr._save_report_to_md('hello', tmp_path)
     report = tmp_path / dr.REPORT_FILENAME
     assert report.read_text() == 'hello'
 
 
-def test_load_previous_state_invalid(tmp_path):  # gracefully handle bad state files
+def test_load_previous_state_invalid(tmp_path):
+    """Gracefully handle malformed saved state files."""  #(added docstring summarizing test intent)
+    # gracefully handle bad state files
     (tmp_path / dr.PLAN_FILENAME).write_text('- [ ] task\n')  # // create plan file for loading
     (tmp_path / dr.SEARCH_INFO_FILENAME).write_text('{bad')  # // invalid json should trigger error
     state = dr._load_previous_state('tid', str(tmp_path))
@@ -146,7 +158,9 @@ def test_load_previous_state_invalid(tmp_path):  # gracefully handle bad state f
     assert 'error_message' in state and 'Failed to load search results' in state['error_message']  # // error message surfaced
 
 
-def test_save_plan_and_search_files(tmp_path):  # persist plan and search data
+def test_save_plan_and_search_files(tmp_path):
+    """Write research plan markdown and search results JSON."""  #(added docstring summarizing test intent)
+    # persist plan and search data
     plan = [
         {'step': 1, 'task': 'a', 'status': 'pending', 'queries': None, 'result_summary': None},
         {'step': 2, 'task': 'b', 'status': 'completed', 'queries': None, 'result_summary': None},
@@ -161,7 +175,9 @@ def test_save_plan_and_search_files(tmp_path):  # persist plan and search data
     assert saved == results  # // json saved correctly
 
 
-def test_setup_tools(monkeypatch):  # default tool set without MCP
+def test_setup_tools(monkeypatch):
+    """Create default tool set when MCP not configured."""  #(added docstring summarizing test intent)
+    # default tool set without MCP
     monkeypatch.setattr(dr.DeepResearchAgent, '_compile_graph', lambda self: None)  # // avoid constructing StateGraph
     agent = dr.DeepResearchAgent('llm', {'b': True})
     monkeypatch.setattr(dr, 'create_browser_search_tool', lambda *a, **k: types.SimpleNamespace(name='browser'))  # // replace browser tool factory
@@ -170,7 +186,9 @@ def test_setup_tools(monkeypatch):  # default tool set without MCP
     assert names == {'WriteFileTool', 'ReadFileTool', 'ListDirectoryTool', 'browser'}  # // default tools built
 
 
-def test_setup_tools_with_mcp(monkeypatch):  # include tools from MCP client
+def test_setup_tools_with_mcp(monkeypatch):
+    """Include MCP client tools when configuration provided."""  #(added docstring summarizing test intent)
+    # include tools from MCP client
     class DummyClient:
         def get_tools(self):
             return [types.SimpleNamespace(name='mcp')]

--- a/tests/browser/test_custom_browser.py
+++ b/tests/browser/test_custom_browser.py
@@ -78,7 +78,9 @@ class Config:
         self.browser_binary_path = kwargs.get("browser_binary_path")
 
 
-def test_setup_builtin_browser_headless(monkeypatch):  # headless config adds required args
+def test_setup_builtin_browser_headless(monkeypatch):
+    """Headless mode should include all required Chrome flags."""  #(added docstring summarizing test intent)
+    # headless config adds required args
     cfg = Config(headless=True, disable_security=True, deterministic_rendering=True, extra_browser_args=["--foo"])  # configuration for headless
     browser = CustomBrowser(config=cfg)  # create browser instance
     pw = Playwright()  # stub Playwright object
@@ -92,7 +94,9 @@ def test_setup_builtin_browser_headless(monkeypatch):  # headless config adds re
     expected = {"--base", "--headless", "--no-sec", "--det", "--window-position=0,0", "--foo", "--window-size=1920,1080", "--remote-debugging-port=9222"}  # expected args
     assert args == expected  # verify all args
 
-def test_setup_builtin_browser_port_conflict(monkeypatch):  # omit debug port when in use
+def test_setup_builtin_browser_port_conflict(monkeypatch):
+    """Skip remote debugging when port 9222 is unavailable."""  #(added docstring summarizing test intent)
+    # omit debug port when in use
     cfg = Config(headless=False, extra_browser_args=[])  # configuration no headless
     browser = CustomBrowser(config=cfg)  # create browser instance
     pw = Playwright()  # stub Playwright

--- a/tests/browser/test_custom_browser_context_creation.py
+++ b/tests/browser/test_custom_browser_context_creation.py
@@ -74,7 +74,9 @@ class SimpleConfig:
     def model_dump(self):
         return self.__dict__
 
-def test_new_context_merges_config():  # browser and context configs are combined
+def test_new_context_merges_config():
+    """Ensure browser and context configurations are merged."""  #(added docstring summarizing test intent)
+    # browser and context configs are combined
     browser_cfg = SimpleConfig(foo=1)  # (simple browser config)
     browser = CustomBrowser(config=browser_cfg)  # (instantiate browser)
     ctx_cfg = SimpleConfig(bar=2)  # (context config)

--- a/tests/browser/test_custom_context.py
+++ b/tests/browser/test_custom_context.py
@@ -85,7 +85,9 @@ def make_config(**kwargs):
     base.update(kwargs)
     return SimpleNamespace(**base)
 
-def test_reuse_existing_context(monkeypatch):  # second call reuses first context
+def test_reuse_existing_context(monkeypatch):
+    """Second call should reuse the first Playwright context."""  #(added docstring summarizing test intent)
+    # second call reuses first context
     pw_browser = DummyPWBrowser()  # stub PlaywrightBrowser
     browser_config = SimpleNamespace(cdp_url="ws://x", browser_binary_path=None)  # config for reuse
     browser = BrowserBase(browser_config)  # create browser
@@ -98,7 +100,9 @@ def test_reuse_existing_context(monkeypatch):  # second call reuses first contex
     assert ctx2 is ctx1  # same context reused
     assert not pw_browser.new_called  # no new context created
 
-def test_load_cookies_and_scripts(tmp_path):  # cookies loaded and script injected
+def test_load_cookies_and_scripts(tmp_path):
+    """Load cookie file and inject navigator override script."""  #(added docstring summarizing test intent)
+    # cookies loaded and script injected
     cookie_file = tmp_path / "c.json"  # path for cookie file
     with open(cookie_file, "w") as f:
         json.dump([{"name": "a", "value": "1", "sameSite": "Bad"}], f)  # write cookie
@@ -111,7 +115,9 @@ def test_load_cookies_and_scripts(tmp_path):  # cookies loaded and script inject
     assert ctx.added_cookies == [{"name": "a", "value": "1", "sameSite": "None"}]  # cookie fixed
     assert any("navigator" in s for s in ctx.init_scripts)  # script injected
 
-def test_malformed_cookies_file(monkeypatch):  # malformed cookie file logs error
+def test_malformed_cookies_file(monkeypatch):
+    """Gracefully log errors for malformed cookie files."""  #(added docstring summarizing test intent)
+    # malformed cookie file logs error
     pw_browser = DummyPWBrowser()  # stub PlaywrightBrowser
     browser = BrowserBase(SimpleNamespace(cdp_url=None, browser_binary_path=None))  # browser without reuse condition
     cfg = make_config(cookies_file="bad.json")  # config with bad cookie file

--- a/tests/components/test_agent_settings_tab.py
+++ b/tests/components/test_agent_settings_tab.py
@@ -109,7 +109,9 @@ class DummyManager:
         self.bu_controller = controller
 
 
-def test_update_model_dropdown_known(monkeypatch):  # provider known -> dropdown populated
+def test_update_model_dropdown_known(monkeypatch):
+    """Selecting a known provider populates the model dropdown."""  #(added docstring summarizing test intent)
+    # provider known -> dropdown populated
     mod = load_agent_settings_tab(monkeypatch)
     dd = mod.update_model_dropdown('openai')
     assert dd.choices == mod.config.model_names['openai']
@@ -117,7 +119,9 @@ def test_update_model_dropdown_known(monkeypatch):  # provider known -> dropdown
     assert dd.interactive
 
 
-def test_update_model_dropdown_unknown(monkeypatch):  # unknown provider -> empty dropdown
+def test_update_model_dropdown_unknown(monkeypatch):
+    """Unknown provider yields an empty, customisable dropdown."""  #(added docstring summarizing test intent)
+    # unknown provider -> empty dropdown
     mod = load_agent_settings_tab(monkeypatch)
     dd = mod.update_model_dropdown('foo')
     assert dd.choices == []
@@ -125,14 +129,18 @@ def test_update_model_dropdown_unknown(monkeypatch):  # unknown provider -> empt
     assert dd.allow_custom_value
 
 
-def test_update_mcp_server_invalid(monkeypatch, tmp_path):  # invalid path hides config
+def test_update_mcp_server_invalid(monkeypatch, tmp_path):
+    """Hide MCP config UI when file does not exist."""  #(added docstring summarizing test intent)
+    # invalid path hides config
     mod = load_agent_settings_tab(monkeypatch)
     mgr = DummyManager()
     result = asyncio.run(mod.update_mcp_server(str(tmp_path / 'no.json'), mgr))
     assert result == (None, mod.gr.update(visible=False))
 
 
-def test_update_mcp_server_valid(monkeypatch, tmp_path):  # valid path loads config JSON
+def test_update_mcp_server_valid(monkeypatch, tmp_path):
+    """Load MCP server configuration from JSON file."""  #(added docstring summarizing test intent)
+    # valid path loads config JSON
     mod = load_agent_settings_tab(monkeypatch)
     data = {'a': 1}
     json_file = tmp_path / 'cfg.json'

--- a/tests/components/test_browser_settings_tab.py
+++ b/tests/components/test_browser_settings_tab.py
@@ -191,7 +191,9 @@ class FakeTask:
     def done(self):
         return False
 
-def test_checkbox_change_triggers_cleanup(monkeypatch):  # toggling checkboxes closes active browser
+def test_checkbox_change_triggers_cleanup(monkeypatch):
+    """Changing settings should close any active browser resources."""  #(added docstring summarizing test intent)
+    # toggling checkboxes closes active browser
     manager = WebuiManager()
     manager.init_browser_use_agent()
 

--- a/tests/components/test_browser_use_agent_tab_buttons.py
+++ b/tests/components/test_browser_use_agent_tab_buttons.py
@@ -166,7 +166,9 @@ async def collect(gen):
         res.append(item)
     return res
 
-def test_handle_submit_running(monkeypatch):  # ignore input when task running
+def test_handle_submit_running(monkeypatch):
+    """Ignore submit events while an agent task is active."""  #(added docstring summarizing test intent)
+    # ignore input when task running
     mod, Manager, _ = load_tab(monkeypatch)
     mgr, comps = make_manager(mod, Manager)
     class DummyTask:
@@ -179,7 +181,9 @@ def test_handle_submit_running(monkeypatch):  # ignore input when task running
     assert results == [{}]
 
 
-def test_handle_submit_new_task(monkeypatch):  # submitting text starts agent
+def test_handle_submit_new_task(monkeypatch):
+    """Submitting user input should launch a new agent task."""  #(added docstring summarizing test intent)
+    # submitting text starts agent
     mod, Manager, _ = load_tab(monkeypatch)
     mgr, comps = make_manager(mod, Manager)
     async def fake_run(m, c):
@@ -191,7 +195,9 @@ def test_handle_submit_new_task(monkeypatch):  # submitting text starts agent
     assert results == [{"ok": True}]
 
 
-def test_handle_pause_resume(monkeypatch):  # toggle pause state of running agent
+def test_handle_pause_resume(monkeypatch):
+    """Pause or resume the running agent when button clicked."""  #(added docstring summarizing test intent)
+    # toggle pause state of running agent
     mod, Manager, _ = load_tab(monkeypatch)
     mgr, comps = make_manager(mod, Manager)
     mgr.bu_agent = mod.BrowserUseAgent()
@@ -205,14 +211,18 @@ def test_handle_pause_resume(monkeypatch):  # toggle pause state of running agen
     assert mgr.bu_agent.state.paused
 
 
-def test_handle_pause_resume_no_task(monkeypatch):  # pause ignored when no task
+def test_handle_pause_resume_no_task(monkeypatch):
+    """Pause/resume click has no effect when no task running."""  #(added docstring summarizing test intent)
+    # pause ignored when no task
     mod, Manager, _ = load_tab(monkeypatch)
     mgr, _ = make_manager(mod, Manager)
     res = asyncio.run(mod.handle_pause_resume(mgr))
     assert res == {}
 
 
-def test_handle_stop_running(monkeypatch):  # stop button halts agent
+def test_handle_stop_running(monkeypatch):
+    """Stop button should halt the agent and disable controls."""  #(added docstring summarizing test intent)
+    # stop button halts agent
     mod, Manager, _ = load_tab(monkeypatch)
     mgr, comps = make_manager(mod, Manager)
     mgr.bu_agent = mod.BrowserUseAgent()
@@ -230,7 +240,9 @@ def test_handle_stop_running(monkeypatch):  # stop button halts agent
     assert res[rb] == mod.gr.update(interactive=False)
 
 
-def test_handle_stop_no_task(monkeypatch):  # stop without active task resets UI
+def test_handle_stop_no_task(monkeypatch):
+    """Stop click when idle resets button states."""  #(added docstring summarizing test intent)
+    # stop without active task resets UI
     mod, Manager, _ = load_tab(monkeypatch)
     mgr, comps = make_manager(mod, Manager)
     res = asyncio.run(mod.handle_stop(mgr))
@@ -244,7 +256,9 @@ def test_handle_stop_no_task(monkeypatch):  # stop without active task resets UI
     assert res[cb] == mod.gr.update(interactive=True)
 
 
-def test_handle_clear(monkeypatch):  # clear button cancels task and resets state
+def test_handle_clear(monkeypatch):
+    """Clear button cancels task and resets manager state."""  #(added docstring summarizing test intent)
+    # clear button cancels task and resets state
     mod, Manager, Controller = load_tab(monkeypatch)
     mgr, comps = make_manager(mod, Manager)
     mgr.bu_agent = mod.BrowserUseAgent()

--- a/tests/components/test_browser_use_agent_tab_helpers.py
+++ b/tests/components/test_browser_use_agent_tab_helpers.py
@@ -99,7 +99,9 @@ class AgentOutputLike:
         self.current_state = current_state
 
 
-def test_get_config_value_primary_tab(helpers_module):  # fetch value from primary tab
+def test_get_config_value_primary_tab(helpers_module):
+    """Retrieve configuration value from the active tab components."""  #(added docstring summarizing test intent)
+    # fetch value from primary tab
     mod, WebuiManager = helpers_module
     manager = WebuiManager()
     comp = DummyComponent()
@@ -108,7 +110,9 @@ def test_get_config_value_primary_tab(helpers_module):  # fetch value from prima
     assert mod._get_config_value(manager, comp_dict, "test", "def") == 42
 
 
-def test_get_config_value_fallback_tabs(helpers_module):  # fallback to other tabs when missing
+def test_get_config_value_fallback_tabs(helpers_module):
+    """Look for configuration values in alternate tabs when absent."""  #(added docstring summarizing test intent)
+    # fallback to other tabs when missing
     mod, WebuiManager = helpers_module
     manager = WebuiManager()
     comp = DummyComponent()
@@ -117,14 +121,18 @@ def test_get_config_value_fallback_tabs(helpers_module):  # fallback to other ta
     assert mod._get_config_value(manager, comp_dict, "test", None) == "ok"
 
 
-def test_get_config_value_default(helpers_module):  # use provided default when absent
+def test_get_config_value_default(helpers_module):
+    """Return provided default when value is missing in all tabs."""  #(added docstring summarizing test intent)
+    # use provided default when absent
     mod, WebuiManager = helpers_module
     manager = WebuiManager()
     manager.comps = {}
     assert mod._get_config_value(manager, {}, "missing", "dft") == "dft"
 
 
-def test_format_agent_output_json(helpers_module):  # format AgentOutput to JSON block
+def test_format_agent_output_json(helpers_module):
+    """Convert AgentOutput object to formatted JSON markup."""  #(added docstring summarizing test intent)
+    # format AgentOutput to JSON block
     mod, _ = helpers_module
     ao = AgentOutputLike([Dumpable("a")], Dumpable("s"))
     res = mod._format_agent_output(ao)
@@ -135,7 +143,9 @@ def test_format_agent_output_json(helpers_module):  # format AgentOutput to JSON
     assert data == {"current_state": {"data": "s"}, "action": [{"data": "a"}]}
 
 
-def test_format_agent_output_attribute_error(helpers_module):  # handle objects lacking model_dump
+def test_format_agent_output_attribute_error(helpers_module):
+    """Handle objects without model_dump when formatting output."""  #(added docstring summarizing test intent)
+    # handle objects lacking model_dump
     mod, _ = helpers_module
     class NoDump:
         pass

--- a/tests/components/test_deep_research_agent_tab.py
+++ b/tests/components/test_deep_research_agent_tab.py
@@ -98,14 +98,18 @@ class DummyAgent:
 
 
 
-def test_read_file_safe_valid(monkeypatch, tmp_path):  # return file contents when readable
+def test_read_file_safe_valid(monkeypatch, tmp_path):
+    """Reading an existing file returns its text contents."""  #(added docstring summarizing test intent)
+    # return file contents when readable
     mod = load_deep_tab(monkeypatch)
     file_path = tmp_path / "f.txt"
     file_path.write_text("hello")
     assert mod._read_file_safe(str(file_path)) == "hello"
 
 
-def test_read_file_safe_error(monkeypatch, caplog):  # log and return None on error
+def test_read_file_safe_error(monkeypatch, caplog):
+    """Errors while reading result in log entry and None."""  #(added docstring summarizing test intent)
+    # log and return None on error
     mod = load_deep_tab(monkeypatch)
     monkeypatch.setattr(mod.os.path, "exists", lambda p: True)
     monkeypatch.setattr("builtins.open", lambda *a, **k: (_ for _ in ()).throw(OSError("bad")))
@@ -115,7 +119,9 @@ def test_read_file_safe_error(monkeypatch, caplog):  # log and return None on er
     assert "Error reading file missing.txt" in caplog.text
 
 
-def test_update_mcp_server_invalid(monkeypatch):  # invalid config path hides config
+def test_update_mcp_server_invalid(monkeypatch):
+    """Hide configuration view if MCP config file is invalid."""  #(added docstring summarizing test intent)
+    # invalid config path hides config
     mod = load_deep_tab(monkeypatch)
     mgr = DummyManager()
     mgr.dr_agent = DummyAgent()
@@ -126,7 +132,9 @@ def test_update_mcp_server_invalid(monkeypatch):  # invalid config path hides co
     assert mgr.dr_agent.closed
 
 
-def test_update_mcp_server_valid(monkeypatch):  # valid config loads and shows JSON
+def test_update_mcp_server_valid(monkeypatch):
+    """Display loaded MCP configuration JSON."""  #(added docstring summarizing test intent)
+    # valid config loads and shows JSON
     mod = load_deep_tab(monkeypatch)
     mgr = DummyManager()
     mgr.dr_agent = DummyAgent()
@@ -138,7 +146,9 @@ def test_update_mcp_server_valid(monkeypatch):  # valid config loads and shows J
     assert mgr.dr_agent.closed
 
 
-def test_stop_deep_research_running(monkeypatch, tmp_path):  # stop agent and expose report file
+def test_stop_deep_research_running(monkeypatch, tmp_path):
+    """Stop a running deep research agent and show final report."""  #(added docstring summarizing test intent)
+    # stop agent and expose report file
     mod = load_deep_tab(monkeypatch)
     mgr = DummyManager()
     names = [

--- a/tests/components/test_load_save_config_tab.py
+++ b/tests/components/test_load_save_config_tab.py
@@ -96,7 +96,9 @@ from src.webui.components import load_save_config_tab  # (import component)
 from src.webui.webui_manager import WebuiManager  # (import manager)
 
 
-def test_load_latest_config(tmp_path, monkeypatch):  # load most recent config file
+def test_load_latest_config(tmp_path, monkeypatch):
+    """Load the most recently modified configuration file on startup."""  #(added docstring summarizing test intent)
+    # load most recent config file
     old = tmp_path / "old.json"  # (older config file path)
     old.write_text("{}")  # (create empty json)
     time.sleep(0.01)  # (ensure timestamp difference)

--- a/tests/controller/test_custom_controller.py
+++ b/tests/controller/test_custom_controller.py
@@ -6,7 +6,9 @@ import types
 sys.path.append('.')
 
 
-def test_register_and_close(monkeypatch):  # ensure actions register and MCP client closes
+def test_register_and_close(monkeypatch):
+    """Verify action registration and proper cleanup of MCP client."""  #(added docstring summarizing test intent)
+    # ensure actions register and MCP client closes
     # create stubs for external dependencies
     pydantic_stub = types.ModuleType('pydantic')
     class BaseModel:  # simple BaseModel stub

--- a/tests/integration/test_run_agent_task.py
+++ b/tests/integration/test_run_agent_task.py
@@ -230,7 +230,9 @@ def teardown_stubs(modules):
 import importlib
 
 
-def test_run_agent_task_simple(tmp_path):  # run agent task successfully with input
+def test_run_agent_task_simple(tmp_path):
+    """Execute a basic browser agent task and expect success."""  #(added docstring summarizing test intent)
+    # run agent task successfully with input
     modules = setup_stubs()
     orig_manager = sys.modules.pop("src.webui.webui_manager", None)
     orig_tab = sys.modules.pop("src.webui.components.browser_use_agent_tab", None)
@@ -295,7 +297,9 @@ def test_run_agent_task_simple(tmp_path):  # run agent task successfully with in
     teardown_stubs(modules)
 
 
-def test_run_agent_task_missing_input(tmp_path):  # empty input should not start agent
+def test_run_agent_task_missing_input(tmp_path):
+    """Submitting empty input should not start an agent task."""  #(added docstring summarizing test intent)
+    # empty input should not start agent
     modules = setup_stubs()
     orig_manager = sys.modules.pop("src.webui.webui_manager", None)
     orig_tab = sys.modules.pop("src.webui.components.browser_use_agent_tab", None)
@@ -355,7 +359,9 @@ def test_run_agent_task_missing_input(tmp_path):  # empty input should not start
     teardown_stubs(modules)
 
 
-def test_run_agent_task_invalid_mcp_config(tmp_path):  # invalid MCP config shows error message
+def test_run_agent_task_invalid_mcp_config(tmp_path):
+    """Invalid MCP configuration should surface an error message."""  #(added docstring summarizing test intent)
+    # invalid MCP config shows error message
     modules = setup_stubs()
     orig_manager = sys.modules.pop("src.webui.webui_manager", None)
     orig_tab = sys.modules.pop("src.webui.components.browser_use_agent_tab", None)

--- a/tests/integration/test_run_deep_research.py
+++ b/tests/integration/test_run_deep_research.py
@@ -207,7 +207,9 @@ def teardown_stubs(modules):
 
 
 
-def test_run_deep_research_simple(tmp_path, monkeypatch):  # run deep research workflow end-to-end
+def test_run_deep_research_simple(tmp_path, monkeypatch):
+    """Execute deep research agent workflow end-to-end."""  #(added docstring summarizing test intent)
+    # run deep research workflow end-to-end
     modules = setup_stubs()
     orig_manager = sys.modules.pop("src.webui.webui_manager", None)
     orig_tab = sys.modules.pop("src.webui.components.deep_research_agent_tab", None)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -22,6 +22,7 @@ from src.utils import utils
 
 
 async def test_browser_use_agent():
+    """Run a browser-use agent end-to-end with manual config."""  #(added docstring summarizing test intent)
     from browser_use.browser.browser import Browser, BrowserConfig
     from browser_use.browser.context import (
         BrowserContextConfig,
@@ -171,6 +172,7 @@ async def test_browser_use_agent():
 
 
 async def test_browser_use_parallel():
+    """Run multiple agents in parallel to validate concurrency logic."""  #(added docstring summarizing test intent)
     pytest.importorskip("patchright", reason="patchright required")  # (skip if patchright missing)
     from browser_use.browser.context import BrowserContextWindowSize
     from browser_use.browser.browser import BrowserConfig
@@ -340,6 +342,7 @@ async def test_browser_use_parallel():
 
 
 async def test_deep_research_agent():
+    """Run the DeepResearchAgent workflow using real tools."""  #(added docstring summarizing test intent)
     from src.agent.deep_research.deep_research_agent import DeepResearchAgent, PLAN_FILENAME, REPORT_FILENAME
     from src.utils import llm_provider
 

--- a/tests/test_browser_launch.py
+++ b/tests/test_browser_launch.py
@@ -5,7 +5,9 @@ sys.path.append(".")  # allow src import
 from src.utils.browser_launch import build_browser_launch_options  # import util
 
 
-def test_default_behavior_without_env(monkeypatch):  # use defaults when env vars absent
+def test_default_behavior_without_env(monkeypatch):
+    """Use default config when no environment overrides are provided."""  #(added docstring summarizing test intent)
+    # use defaults when env vars absent
     monkeypatch.delenv("CHROME_PATH", raising=False)  # remove env path
     monkeypatch.delenv("CHROME_USER_DATA", raising=False)  # remove env data
     config = {"window_width": 800, "window_height": 600, "use_own_browser": False}  # default config
@@ -14,7 +16,9 @@ def test_default_behavior_without_env(monkeypatch):  # use defaults when env var
     assert args == ["--window-size=800,600"]  # only window size
 
 
-def test_own_browser_env(monkeypatch):  # prefer env variables over config
+def test_own_browser_env(monkeypatch):
+    """Environment variables take precedence over config options."""  #(added docstring summarizing test intent)
+    # prefer env variables over config
     monkeypatch.setenv("CHROME_PATH", "/env/chrome")  # set env path
     monkeypatch.setenv("CHROME_USER_DATA", "/env/profile")  # set env data
     config = {
@@ -33,7 +37,9 @@ def test_own_browser_env(monkeypatch):  # prefer env variables over config
     ]  # all args present
 
 
-def test_empty_env_path(monkeypatch):  # empty CHROME_PATH results in None
+def test_empty_env_path(monkeypatch):
+    """Ensure empty CHROME_PATH environment variable is treated as None."""  #(added docstring summarizing test intent)
+    # empty CHROME_PATH results in None
     monkeypatch.setenv("CHROME_PATH", "")  # empty env value
     monkeypatch.delenv("CHROME_USER_DATA", raising=False)  # no env data
     config = {

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -21,7 +21,9 @@ logger = logging.getLogger(__name__)  # (added logger for debug output)
 
 
 @pytest.mark.skip(reason="requires MCP servers and manual checks")
-async def test_mcp_client():  # connect to MCP servers and enumerate tools
+async def test_mcp_client():
+    """Connect to MCP servers and print available tool schemas."""  #(added docstring summarizing test intent)
+    # connect to MCP servers and enumerate tools
     from src.utils.mcp_client import setup_mcp_client_and_tools, create_tool_param_model
 
     test_server_config = {
@@ -53,7 +55,9 @@ async def test_mcp_client():  # connect to MCP servers and enumerate tools
 
 
 @pytest.mark.skip(reason="requires MCP servers and manual checks")
-async def test_controller_with_mcp():  # run controller action through MCP
+async def test_controller_with_mcp():
+    """Run a controller action using the MCP client."""  #(added docstring summarizing test intent)
+    # run controller action through MCP
     import os
     from src.controller.custom_controller import CustomController
     from browser_use.controller.registry.views import ActionModel

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -98,58 +98,80 @@ def test_llm(config, query, image_path=None, system_message=None):  # helper to 
         print(ai_msg.reasoning_content)
     print(ai_msg.content)
 
-def test_openai_model():  # verify OpenAI provider path
+def test_openai_model():
+    """Verify OpenAI provider integration path."""  #(added docstring summarizing test intent)
+    # verify OpenAI provider path
     config = LLMConfig(provider="openai", model_name="gpt-4o")
     test_llm(config, "Describe this image", "assets/examples/test.png")
 
 
-def test_google_model():  # verify Google provider path
+def test_google_model():
+    """Verify Google provider integration path."""  #(added docstring summarizing test intent)
+    # verify Google provider path
     # Enable your API key first if you haven't: https://ai.google.dev/palm_docs/oauth_quickstart
     config = LLMConfig(provider="google", model_name="gemini-2.0-flash-exp")
     test_llm(config, "Describe this image", "assets/examples/test.png")
 
 
-def test_azure_openai_model():  # verify Azure OpenAI provider path
+def test_azure_openai_model():
+    """Verify Azure OpenAI provider integration path."""  #(added docstring summarizing test intent)
+    # verify Azure OpenAI provider path
     config = LLMConfig(provider="azure_openai", model_name="gpt-4o")
     test_llm(config, "Describe this image", "assets/examples/test.png")
 
 
-def test_deepseek_model():  # verify DeepSeek provider path
+def test_deepseek_model():
+    """Verify DeepSeek provider integration path."""  #(added docstring summarizing test intent)
+    # verify DeepSeek provider path
     config = LLMConfig(provider="deepseek", model_name="deepseek-chat")
     test_llm(config, "Who are you?")
 
 
-def test_deepseek_r1_model():  # verify DeepSeek Reasoner path
+def test_deepseek_r1_model():
+    """Verify DeepSeek Reasoner model works via API."""  #(added docstring summarizing test intent)
+    # verify DeepSeek Reasoner path
     config = LLMConfig(provider="deepseek", model_name="deepseek-reasoner")
     test_llm(config, "Which is greater, 9.11 or 9.8?", system_message="You are a helpful AI assistant.")
 
 
-def test_ollama_model():  # verify Ollama provider path
+def test_ollama_model():
+    """Verify Ollama provider integration path."""  #(added docstring summarizing test intent)
+    # verify Ollama provider path
     config = LLMConfig(provider="ollama", model_name="qwen2.5:7b")
     test_llm(config, "Sing a ballad of LangChain.")
 
 
-def test_deepseek_r1_ollama_model():  # verify DeepSeek R1 via Ollama
+def test_deepseek_r1_ollama_model():
+    """Verify DeepSeek R1 model served via Ollama."""  #(added docstring summarizing test intent)
+    # verify DeepSeek R1 via Ollama
     config = LLMConfig(provider="ollama", model_name="deepseek-r1:14b")
     test_llm(config, "How many 'r's are in the word 'strawberry'?")
 
 
-def test_mistral_model():  # verify Mistral provider path
+def test_mistral_model():
+    """Verify Mistral provider integration path."""  #(added docstring summarizing test intent)
+    # verify Mistral provider path
     config = LLMConfig(provider="mistral", model_name="pixtral-large-latest")
     test_llm(config, "Describe this image", "assets/examples/test.png")
 
 
-def test_moonshot_model():  # verify Moonshot provider path
+def test_moonshot_model():
+    """Verify Moonshot provider integration path."""  #(added docstring summarizing test intent)
+    # verify Moonshot provider path
     config = LLMConfig(provider="moonshot", model_name="moonshot-v1-32k-vision-preview")
     test_llm(config, "Describe this image", "assets/examples/test.png")
 
 
-def test_ibm_model():  # verify IBM provider path
+def test_ibm_model():
+    """Verify IBM provider integration path."""  #(added docstring summarizing test intent)
+    # verify IBM provider path
     config = LLMConfig(provider="ibm", model_name="meta-llama/llama-4-maverick-17b-128e-instruct-fp8")
     test_llm(config, "Describe this image", "assets/examples/test.png")
 
 
-def test_qwen_model():  # verify Alibaba Qwen provider path
+def test_qwen_model():
+    """Verify Alibaba Qwen provider integration path."""  #(added docstring summarizing test intent)
+    # verify Alibaba Qwen provider path
     config = LLMConfig(provider="alibaba", model_name="qwen3-30b-a3b")
     test_llm(config, "How many 'r's are in the word 'strawberry'?")
 

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -18,7 +18,9 @@ logger = logging.getLogger(__name__)  # (added logger for debug output)
 
 
 @pytest.mark.skip(reason="requires manual browser interaction")
-def test_connect_browser():  # manually launch Playwright browser
+def test_connect_browser():
+    """Launch a Playwright browser to verify manual connection works."""  #(added docstring summarizing test intent)
+    # manually launch Playwright browser
     import os
     from patchright.sync_api import sync_playwright
 

--- a/tests/test_webui_cli.py
+++ b/tests/test_webui_cli.py
@@ -6,7 +6,8 @@ import pytest
 skip = importlib.util.find_spec("dotenv") is None or importlib.util.find_spec("gradio") is None
 
 @pytest.mark.skipif(skip, reason="required packages missing")
-def test_webui_help_runs():  # ensure CLI help prints usage
+def test_webui_help_runs():
+    """Run the CLI with --help and verify usage text appears."""  #(added docstring summarizing test intent)
     result = subprocess.run([sys.executable, 'webui.py', '--help'], capture_output=True, text=True)  # run CLI
     assert result.returncode == 0  # exit success
     assert 'usage:' in result.stdout.lower()  # usage text present

--- a/tests/utils/test_agent_utils.py
+++ b/tests/utils/test_agent_utils.py
@@ -22,14 +22,18 @@ from unittest.mock import patch
 from src.utils.agent_utils import initialize_llm
 
 
-def test_initialize_llm_missing_fields():  # missing provider or model returns None
+def test_initialize_llm_missing_fields():
+    """Return None when provider or model fields are missing."""  #(added docstring summarizing test intent)
+    # missing provider or model returns None
     result = asyncio.run(initialize_llm(None, 'm', 0.5, None, None))
     assert result is None
     result = asyncio.run(initialize_llm('p', None, 0.5, None, None))
     assert result is None
 
 
-def test_initialize_llm_success():  # successful initialization returns model
+def test_initialize_llm_success():
+    """Successfully initialize LLM and verify parameter passing."""  #(added docstring summarizing test intent)
+    # successful initialization returns model
     mock_model = object()
     with patch('src.utils.agent_utils.llm_provider.get_llm_model', return_value=mock_model) as get_model:
         result = asyncio.run(initialize_llm('openai', 'gpt', 0.3, 'url', 'key'))
@@ -44,7 +48,9 @@ def test_initialize_llm_success():  # successful initialization returns model
     assert result is mock_model
 
 
-def test_initialize_llm_exception():  # errors during creation are logged and None returned
+def test_initialize_llm_exception():
+    """Return None and log errors when LLM initialization fails."""  #(added docstring summarizing test intent)
+    # errors during creation are logged and None returned
     with patch('src.utils.agent_utils.llm_provider.get_llm_model', side_effect=Exception('boom')):
         with patch('src.utils.agent_utils.logger') as log:
             with patch('src.utils.agent_utils.gr.Warning') as warn:

--- a/tests/utils/test_browser_cleanup.py
+++ b/tests/utils/test_browser_cleanup.py
@@ -5,7 +5,9 @@ from unittest.mock import AsyncMock, patch  # mocking async objects
 from src.utils.browser_cleanup import close_browser_resources  # function to test
 
 
-def test_close_browser_resources_success():  # check normal closure
+def test_close_browser_resources_success():
+    """Browser and context close successfully when cleanup is called."""  #(added docstring summarizing test intent)
+    # check normal closure
     browser = AsyncMock()  # fake browser
     context = AsyncMock()  # fake context
     with patch('src.utils.browser_cleanup.logger') as log:  # patch logger
@@ -20,7 +22,9 @@ def test_close_browser_resources_success():  # check normal closure
         )
 
 
-def test_close_browser_resources_errors():  # handle closing errors
+def test_close_browser_resources_errors():
+    """Cleanup logs errors when closing browser or context fails."""  #(added docstring summarizing test intent)
+    # handle closing errors
     browser = AsyncMock()  # fake browser
     context = AsyncMock()  # fake context
     browser.close.side_effect = Exception('b')  # raise on close
@@ -31,14 +35,18 @@ def test_close_browser_resources_errors():  # handle closing errors
         log.error.assert_any_call('Error closing browser: b')  # browser error log
 
 
-def test_close_browser_resources_none():  # call with no browser or context
+def test_close_browser_resources_none():
+    """Calling cleanup with None arguments logs nothing."""  #(added docstring summarizing test intent)
+    # call with no browser or context
     with patch('src.utils.browser_cleanup.logger') as log:  # patch logger
         asyncio.run(close_browser_resources(None, None))  # invoke util with none
         log.info.assert_not_called()  # no info logs expected
         log.error.assert_not_called()  # no error logs expected
 
 
-def test_close_browser_resources_none_logs():  # verify logging
+def test_close_browser_resources_none_logs():
+    """Ensure calling cleanup twice with None does not log."""  #(added docstring summarizing test intent)
+    # verify logging
     with patch('src.utils.browser_cleanup.logger') as log:  # patch logger
         asyncio.run(close_browser_resources(None, None))  # call util again
         log.info.assert_not_called()  # nothing logged as info

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -4,7 +4,9 @@ from unittest.mock import mock_open, patch  # import mocking tools
 from src.utils.file_utils import load_json_safe  # function to test
 
 
-def test_load_json_safe_success():  # parse existing JSON file into dict
+def test_load_json_safe_success():
+    """Parse a valid JSON file and return the resulting dict."""  #(added docstring summarizing test intent)
+    # parse existing JSON file into dict
     data = '{"a": 1}'  # sample json text
     with patch('os.path.exists', return_value=True):  # pretend file exists
         with patch('builtins.open', mock_open(read_data=data)):  # mock file open
@@ -12,7 +14,9 @@ def test_load_json_safe_success():  # parse existing JSON file into dict
     assert result == {"a": 1}  # expect parsed dict
 
 
-def test_load_json_safe_invalid_json():  # invalid JSON logs error and returns None
+def test_load_json_safe_invalid_json():
+    """Invalid JSON should log an error and return None."""  #(added docstring summarizing test intent)
+    # invalid JSON logs error and returns None
     bad = '{invalid'  # malformed json text
     with patch('os.path.exists', return_value=True):  # pretend file exists
         with patch('builtins.open', mock_open(read_data=bad)):  # mock file open
@@ -22,7 +26,9 @@ def test_load_json_safe_invalid_json():  # invalid JSON logs error and returns N
     assert result is None  # expect None result
 
 
-def test_load_json_safe_missing_file():  # nonexistent file yields None
+def test_load_json_safe_missing_file():
+    """Return None when attempting to read a missing file."""  #(added docstring summarizing test intent)
+    # nonexistent file yields None
     with patch('os.path.exists', return_value=False):  # path does not exist
         result = load_json_safe('missing.json')  # call util
     assert result is None  # expect None result

--- a/tests/utils/test_llm_provider.py
+++ b/tests/utils/test_llm_provider.py
@@ -71,13 +71,17 @@ stub_module('langchain_core.tools', {'BaseTool': Dummy})  # (fake tools)
 llm_provider = importlib.import_module('src.utils.llm_provider')  # (import target module)
 
 
-def test_openai_requires_key(monkeypatch):  # missing API key raises error
+def test_openai_requires_key(monkeypatch):
+    """Ensure an API key is required for OpenAI provider."""  #(added docstring summarizing test intent)
+    # missing API key raises error
     monkeypatch.delenv('OPENAI_API_KEY', raising=False)  # (clear env var)
     with pytest.raises(ValueError):  # (expect error)
         llm_provider.get_llm_model('openai')  # (call provider)
 
 
-def test_openai_custom_params(monkeypatch):  # custom params override defaults
+def test_openai_custom_params(monkeypatch):
+    """Custom parameters should override OpenAI defaults."""  #(added docstring summarizing test intent)
+    # custom params override defaults
     monkeypatch.setenv('OPENAI_API_KEY', 'sk-test')  # (set env var)
     model = llm_provider.get_llm_model(
         'openai', base_url='http://api', temperature=0.5
@@ -87,7 +91,9 @@ def test_openai_custom_params(monkeypatch):  # custom params override defaults
     assert model.kwargs['temperature'] == 0.5  # (verify temperature)
 
 
-def test_ollama_custom_params(monkeypatch):  # ollama provider honors overrides
+def test_ollama_custom_params(monkeypatch):
+    """Ollama provider should honor provided override parameters."""  #(added docstring summarizing test intent)
+    # ollama provider honors overrides
     monkeypatch.delenv('OLLAMA_ENDPOINT', raising=False)  # (clear env var)
     model = llm_provider.get_llm_model(
         'ollama', base_url='http://ollama', temperature=0.1
@@ -97,13 +103,17 @@ def test_ollama_custom_params(monkeypatch):  # ollama provider honors overrides
     assert model.kwargs['temperature'] == 0.1  # (verify temperature)
 
 
-def test_anthropic_requires_key(monkeypatch):  # anthropic needs API key
+def test_anthropic_requires_key(monkeypatch):
+    """Anthropic provider should raise when API key missing."""  #(added docstring summarizing test intent)
+    # anthropic needs API key
     monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)  #(description of change & current functionality)
     with pytest.raises(ValueError):  #(description of change & current functionality)
         llm_provider.get_llm_model('anthropic')  #(description of change & current functionality)
 
 
-def test_anthropic_custom_params(monkeypatch):  # anthropic with overrides works
+def test_anthropic_custom_params(monkeypatch):
+    """Anthropic provider should accept and use custom parameters."""  #(added docstring summarizing test intent)
+    # anthropic with overrides works
     monkeypatch.setenv('ANTHROPIC_API_KEY', 'ant-test')  #(description of change & current functionality)
     model = llm_provider.get_llm_model(  #(description of change & current functionality)
         'anthropic', base_url='https://anthropic', temperature=0.2  #(description of change & current functionality)
@@ -113,7 +123,9 @@ def test_anthropic_custom_params(monkeypatch):  # anthropic with overrides works
     assert model.kwargs['temperature'] == 0.2  #(description of change & current functionality)
 
 
-def test_ollama_no_key(monkeypatch):  # ollama works without explicit key
+def test_ollama_no_key(monkeypatch):
+    """Ollama provider works without an explicit API key."""  #(added docstring summarizing test intent)
+    # ollama works without explicit key
     monkeypatch.delenv('OLLAMA_ENDPOINT', raising=False)  #(description of change & current functionality)
     model = llm_provider.get_llm_model('ollama')  #(description of change & current functionality)
     assert isinstance(model, llm_provider.ChatOllama)  #(description of change & current functionality)

--- a/tests/utils/test_mcp_client.py
+++ b/tests/utils/test_mcp_client.py
@@ -79,14 +79,18 @@ class FailClient(DummyClient):
         raise RuntimeError('fail')
 
 
-def test_setup_mcp_client_success(monkeypatch):  # client created and entered
+def test_setup_mcp_client_success(monkeypatch):
+    """Successful MCP client creation should enter context."""  #(added docstring summarizing test intent)
+    # client created and entered
     monkeypatch.setattr(mcp_client, 'MultiServerMCPClient', SuccessClient)
     client = asyncio.run(setup_mcp_client_and_tools({'a': 1}))
     assert isinstance(client, SuccessClient)
     assert client.entered
 
 
-def test_setup_mcp_client_failure(monkeypatch):  # failure returns None
+def test_setup_mcp_client_failure(monkeypatch):
+    """Return None when MCP client initialization fails."""  #(added docstring summarizing test intent)
+    # failure returns None
     monkeypatch.setattr(mcp_client, 'MultiServerMCPClient', FailClient)
     client = asyncio.run(setup_mcp_client_and_tools({'a': 1}))
     assert client is None
@@ -103,7 +107,9 @@ class FakeTool:
         'required': ['req_field']
     }
 
-def test_create_tool_param_model():  # build pydantic model from tool schema
+def test_create_tool_param_model():
+    """Build a Pydantic model from a tool schema."""  #(added docstring summarizing test intent)
+    # build pydantic model from tool schema
     model = create_tool_param_model(FakeTool)
     ann = model.__annotations__
     assert ann['req_field'] is str
@@ -113,7 +119,9 @@ def test_create_tool_param_model():  # build pydantic model from tool schema
     assert model.opt_enum == 'x'
 
 
-def test_resolve_type_enum_array():  # resolve enum and array JSON types
+def test_resolve_type_enum_array():
+    """Resolve enum and array types from JSON schema."""  #(added docstring summarizing test intent)
+    # resolve enum and array JSON types
     enum_type = resolve_type({'type': 'string', 'enum': ['a', 'b']}, 'test')
     array_type = resolve_type({'type': 'array', 'items': {'type': 'integer'}}, 'nums')
     assert issubclass(enum_type, Enum)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -9,7 +9,9 @@ from unittest.mock import MagicMock, mock_open, patch  # mocking tools
 from src.utils.utils import encode_image, get_latest_files  # functions under test
 
 
-def test_encode_image_success():  # encode bytes and return base64 string
+def test_encode_image_success():
+    """Binary image data should be encoded to base64 string."""  #(added docstring summarizing test intent)
+    # encode bytes and return base64 string
     data = b'abc'  # sample bytes
     m = mock_open(read_data=data)  # mock binary file
     m.return_value.read.return_value = data  # ensure bytes returned
@@ -19,7 +21,9 @@ def test_encode_image_success():  # encode bytes and return base64 string
     assert result == expected  # compare result
 
 
-def test_encode_image_none():  # None path should yield None
+def test_encode_image_none():
+    """None path input should return None from encode_image."""  #(added docstring summarizing test intent)
+    # None path should yield None
     assert encode_image(None) is None  # expect None returned
 
 
@@ -31,7 +35,9 @@ def fake_path(path, mtime):  # helper to build fake Path
     return p  # return mock
 
 
-def test_get_latest_files():  # select most recent file for each extension
+def test_get_latest_files():
+    """Return the latest file per extension from a directory."""  #(added docstring summarizing test intent)
+    # select most recent file for each extension
     webm1 = fake_path('/dir/a.webm', 50)  # older webm
     webm2 = fake_path('/dir/b.webm', 100)  # newer webm
     zip1 = fake_path('/dir/a.zip', 60)  # zip file
@@ -50,7 +56,9 @@ def test_get_latest_files():  # select most recent file for each extension
     assert result['.zip'] == '/dir/a.zip'  # latest zip path
 
 
-def test_get_latest_files_missing_dir():  # handle missing directory by creating it
+def test_get_latest_files_missing_dir():
+    """Create directory when missing and return placeholders."""  #(added docstring summarizing test intent)
+    # handle missing directory by creating it
     with patch('os.path.exists', return_value=False):  # simulate missing dir
         with patch('src.utils.utils.ensure_dir') as mk:  # patch dir helper
             result = get_latest_files('/missing')  # call util


### PR DESCRIPTION
## Summary
- clarify test_webui_cli with a docstring
- document browser launch tests
- add descriptive docstrings to controller and utilities tests
- note intent of integration and component tests
- update async agent tests with short summaries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*