### PR TITLE
Add helper docs

### DIFF
--- a/tests/agent/test_browser_use_agent.py
+++ b/tests/agent/test_browser_use_agent.py
@@ -4,6 +4,7 @@ import asyncio
 
 sys.path.append(".")
 def setup_stubs():
+    """Stub external modules so BrowserUseAgent imports without dependencies."""  #(added docstring explaining helper role)
     modules = {
         'browser_use': types.ModuleType('browser_use'),
         'browser_use.agent': types.ModuleType('browser_use.agent'),

--- a/tests/agent/test_deep_research_agent.py
+++ b/tests/agent/test_deep_research_agent.py
@@ -7,6 +7,7 @@ import pytest
 sys.path.append(".")
 
 def setup_stubs():
+    """Register stub modules needed to import deep research agent code."""  #(added docstring describing stubs purpose)
     modules = {
         'browser_use.browser.browser': types.ModuleType('browser_use.browser.browser'),
         'langchain_community.tools.file_management': types.ModuleType('langchain_community.tools.file_management'),

--- a/tests/browser/test_custom_context.py
+++ b/tests/browser/test_custom_context.py
@@ -64,6 +64,7 @@ class DummyPWBrowser:
         return ctx
 
 def make_config(**kwargs):
+    """Return a context config namespace with provided overrides."""  #(added docstring describing helper purpose)
     base = {
         "force_new_context": False,
         "cookies_file": None,

--- a/tests/components/test_agent_settings_tab.py
+++ b/tests/components/test_agent_settings_tab.py
@@ -13,6 +13,7 @@ class Dummy:
 
 
 def stub_module(monkeypatch, name, attrs=None):
+    """Create a temporary module with given attributes and insert into sys.modules."""  #(added docstring describing helper purpose)
     mod = types.ModuleType(name)
     if attrs:
         for k, v in attrs.items():
@@ -22,6 +23,7 @@ def stub_module(monkeypatch, name, attrs=None):
 
 
 def load_agent_settings_tab(monkeypatch):
+    """Load agent_settings_tab after injecting stubs for external deps."""  #(added docstring describing helper purpose)
     stubs = [
         ('openai', {'OpenAI': Dummy}),
         ('langchain_openai', {'ChatOpenAI': Dummy, 'AzureChatOpenAI': Dummy}),

--- a/tests/components/test_browser_use_agent_tab_buttons.py
+++ b/tests/components/test_browser_use_agent_tab_buttons.py
@@ -6,6 +6,7 @@ sys.path.append(".")
 
 
 def load_tab(monkeypatch):
+    """Import browser_use_agent_tab with all external modules stubbed."""  #(added docstring describing helper purpose)
     # gradio stubs
     gradio = types.ModuleType("gradio")
     comps = types.ModuleType("gradio.components")
@@ -145,6 +146,7 @@ def load_tab(monkeypatch):
 
 
 def make_manager(mod, Manager):
+    """Instantiate WebuiManager and create stub component map."""  #(added docstring describing helper purpose)
     mgr = Manager()
     comps = {
         "browser_use_agent.user_input": mod.gr.Textbox(),
@@ -161,6 +163,7 @@ def make_manager(mod, Manager):
     return mgr, comps
 
 async def collect(gen):
+    """Gather all items from an async generator into a list."""  #(added docstring describing helper purpose)
     res = []
     async for item in gen:
         res.append(item)

--- a/tests/components/test_browser_use_agent_tab_helpers.py
+++ b/tests/components/test_browser_use_agent_tab_helpers.py
@@ -8,6 +8,7 @@ sys.path.append(".")  # allow src imports
 
 
 def install_stubs():
+    """Add stub modules so the browser use tab imports without heavy deps."""  #(added docstring explaining helper purpose)
     gradio_mod = types.ModuleType("gradio")
     comps_mod = types.ModuleType("gradio.components")
     class Component:
@@ -68,6 +69,7 @@ def install_stubs():
 
 
 def remove_stubs(original):
+    """Restore original modules replaced by install_stubs."""  #(added docstring describing cleanup)
     for name, mod in original.items():
         if mod is not None:
             sys.modules[name] = mod

--- a/tests/components/test_deep_research_agent_tab.py
+++ b/tests/components/test_deep_research_agent_tab.py
@@ -38,6 +38,7 @@ class DummyManager:
 
 
 def load_deep_tab(monkeypatch):
+    """Import deep_research_agent_tab with gradio and agent stubs."""  #(added docstring describing helper purpose)
     gradio = types.ModuleType("gradio")
     comps = types.ModuleType("gradio.components")
     comps.Component = DummyComp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ for name in mods:
         setattr(mod, "BrowserState", getattr(mod, "BrowserState", type("BrowserState", (), {})))
 
 def pytest_ignore_collect(path, config):  #(description of change & current functionality)
+    """Skip integration tests when gradio is unavailable."""  #(added docstring explaining hook purpose)
     if path.basename in {"test_webui_integration.py", "test_interface.py", "test_run_deep_research.py"}:  #(description of change & current functionality)
         from importlib.util import find_spec  #(description of change & current functionality)
         try:  #(description of change & current functionality)

--- a/tests/integration/test_run_agent_task.py
+++ b/tests/integration/test_run_agent_task.py
@@ -6,7 +6,7 @@ sys.path.append(".")
 
 
 def setup_stubs():
-    """Insert stub modules for gradio and browser_use dependencies."""
+    """Insert gradio and browser_use stubs so the run tab imports cleanly."""  #(added docstring explaining helper purpose)
     modules = {}
     sys.modules.setdefault("requests", types.ModuleType("requests"))  # stub requests for manager import
 
@@ -223,6 +223,7 @@ def setup_stubs():
 
 
 def teardown_stubs(modules):
+    """Remove previously inserted stub modules from sys.modules."""  #(added docstring describing cleanup)
     for name in modules:
         sys.modules.pop(name, None)
 

--- a/tests/integration/test_run_deep_research.py
+++ b/tests/integration/test_run_deep_research.py
@@ -36,6 +36,7 @@ class DummyNumber(DummyComponent):
 
 
 def preload_stubs():
+    """Create base gradio and browser_use stubs used across tests."""  #(added docstring describing helper purpose)
     gradio = types.ModuleType("gradio")
     comps = types.ModuleType("gradio.components")
     setattr(comps, "Component", DummyComponent)
@@ -102,6 +103,7 @@ preload_stubs()
 
 
 def setup_stubs():
+    """Install per-test stubs and return their module names for cleanup."""  #(added docstring describing helper purpose)
     preload_stubs()  #(description of change & current functionality)
     modules = {}
     sys.modules.setdefault("requests", types.ModuleType("requests"))
@@ -202,6 +204,7 @@ def setup_stubs():
 
 
 def teardown_stubs(modules):
+    """Remove previously added stub modules from sys.modules."""  #(added docstring describing cleanup)
     for name in modules:
         sys.modules.pop(name, None)
 

--- a/tests/utils/test_llm_provider.py
+++ b/tests/utils/test_llm_provider.py
@@ -13,6 +13,7 @@ class Dummy:
 
 
 def stub_module(name, attrs=None):
+    """Insert a simple module with optional attributes for import mocking."""  #(added docstring describing helper purpose)
     mod = types.ModuleType(name)
     if attrs:
         for k, v in attrs.items():

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -28,6 +28,7 @@ def test_encode_image_none():
 
 
 def fake_path(path, mtime):  # helper to build fake Path
+    """Return a mock Path object with predetermined modification time."""  #(added docstring describing helper purpose)
     stat = SimpleNamespace(st_mtime=mtime)  # fake stat object
     p = MagicMock()  # create mock path
     p.stat.return_value = stat  # stub stat


### PR DESCRIPTION
## Summary
- document setup_stubs helpers and other helper utilities
- explain why helpers exist for testing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*