### PR TITLE
Add clarifying docstring for custom context init

### DIFF
--- a/src/browser/custom_context.py
+++ b/src/browser/custom_context.py
@@ -26,6 +26,10 @@ class CustomBrowserContext(BrowserContext):
             config: BrowserContextConfig | None = None,
             state: Optional[BrowserContextState] = None,
     ):
+        """Initialize by delegating to :class:`BrowserContext`.
+
+        The parent class sets up configuration and state, so no extra logic is needed.
+        """  #// added docstring clarifying delegation and lack of extra logic
         super(CustomBrowserContext, self).__init__(browser=browser, config=config, state=state)
 
     async def _create_context(self, browser: PlaywrightBrowser):


### PR DESCRIPTION
## Summary
- document `CustomBrowserContext.__init__` explaining delegation to parent class

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright', 'psutil')*

------
https://chatgpt.com/codex/tasks/task_b_6839da2e48f88322a3f9a1f23a4ccc32