### PR TITLE
Update browser cleanup docstring

### DIFF
--- a/src/webui/components/browser_settings_tab.py
+++ b/src/webui/components/browser_settings_tab.py
@@ -73,10 +73,14 @@ from src.utils.browser_cleanup import close_browser_resources  # shared cleanup 
 
 logger = logging.getLogger(__name__)
 
-async def close_browser(webui_manager: WebuiManager):
+async def close_browser(webui_manager: WebuiManager):  # cancel tasks and release resources when settings change
+    """Close the active browser and reset state.
+
+    Running tasks are cancelled and browser resources are closed so that
+    updated settings can be applied cleanly without leaving stale tasks or
+    memory leaks.
     """
-    Close browser
-    """
+    # expanded docstring to clarify why resources and tasks are cleaned up
     if webui_manager.bu_current_task and not webui_manager.bu_current_task.done():
         webui_manager.bu_current_task.cancel()
         webui_manager.bu_current_task = None


### PR DESCRIPTION
## Summary
- clarify why the browser cleanup function cancels tasks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright', 'psutil')*

------
https://chatgpt.com/codex/tasks/task_b_6839da2fe7708322b321ae5662d38280