### PR TITLE
Implement offline mode for codex

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ IBM_ENDPOINT=https://us-south.ml.cloud.ibm.com
 IBM_API_KEY=
 IBM_PROJECT_ID=
 
+# Enable offline mode when running in the Codex environment
+CODEX=False
+
 # Set to false to disable anonymized telemetry
 ANONYMIZED_TELEMETRY=false
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ copy .env.example .env
 cp .env.example .env
 ```
 2. Open `.env` in your preferred text editor and add your API keys and other settings
+   - Set `CODEX=True` to enable offline mode when developing without internet access
 
 ### Option 2: Docker Installation
 
@@ -108,6 +109,7 @@ copy .env.example .env
 cp .env.example .env
 ```
 Edit `.env` with your preferred text editor and add your API keys
+Set `CODEX=True` if the container will run without internet connectivity
 
 3. Run with Docker:
 ```bash
@@ -184,6 +186,7 @@ CHROME_PERSISTENT_SESSION=true docker compose up --build
 
      # VNC Settings
      VNC_PASSWORD=your_vnc_password  # Optional, defaults to "vncpassword"
+     CODEX=False                     # Set True to mock network calls in offline environments
      ```
 
 2. **Platform Support:**
@@ -237,6 +240,11 @@ CHROME_PERSISTENT_SESSION=true docker compose up --build
    ```bash
    pytest
    ```
+
+## Offline Mode
+Set `CODEX=True` in your `.env` file to mock network operations when the
+environment lacks internet access. This allows tests and the application to run
+without contacting external services.
 
 ## Changelog
 - [x] **2025/01/26:** Thanks to @vvincent1234. Now browser-use-webui can combine with DeepSeek-r1 to engage in deep thinking!

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,1 +1,5 @@
 """Utility helpers shared across the Browser Use project."""  # module docstring describing utilities
+
+from .offline import is_offline, qerrors  # expose offline helpers for reuse
+
+__all__ = ["is_offline", "qerrors"]  # defined exports for convenience

--- a/src/utils/llm_provider.py
+++ b/src/utils/llm_provider.py
@@ -1,5 +1,6 @@
 from openai import OpenAI
 from langchain_openai import ChatOpenAI
+from src.utils.offline import is_offline  # offline helper for CODEX mode
 from langchain_core.globals import get_llm_cache
 from langchain_core.language_models.base import (
     BaseLanguageModel,
@@ -146,7 +147,7 @@ class DeepSeekR1ChatOpenAI(ChatOpenAI):
             else:
                 message_history.append({"role": "user", "content": input_.content})
 
-        if os.getenv('CODEX') != 'True':  # use real API when CODEX is not True
+        if not is_offline():  # use real API when CODEX is not True
             response = self.client.chat.completions.create(
                 model=self.model_name,
                 messages=message_history
@@ -175,7 +176,7 @@ class DeepSeekR1ChatOpenAI(ChatOpenAI):
             else:
                 message_history.append({"role": "user", "content": input_.content})
 
-        if os.getenv('CODEX') != 'True':  # real API call when not on Codex
+        if not is_offline():  # real API call when not on Codex
             response = self.client.chat.completions.create(
                 model=self.model_name,
                 messages=message_history
@@ -199,7 +200,7 @@ class DeepSeekR1ChatOllama(ChatOllama):
             stop: Optional[list[str]] = None,
             **kwargs: Any,
     ) -> AIMessage:
-        if os.getenv('CODEX') != 'True':  # run real call when CODEX unset
+        if not is_offline():  # run real call when CODEX unset
             org_ai_message = await super().ainvoke(input=input)
         else:  # mock the ai message when running on Codex
             org_ai_message = AIMessage(content='<think>mock reason</think>mock')
@@ -218,7 +219,7 @@ class DeepSeekR1ChatOllama(ChatOllama):
             stop: Optional[list[str]] = None,
             **kwargs: Any,
     ) -> AIMessage:
-        if os.getenv('CODEX') != 'True':  # run real call when CODEX unset
+        if not is_offline():  # run real call when CODEX unset
             org_ai_message = super().invoke(input=input)
         else:  # mock the ai message when running on Codex
             org_ai_message = AIMessage(content='<think>mock reason</think>mock')

--- a/src/utils/mcp_client.py
+++ b/src/utils/mcp_client.py
@@ -79,6 +79,7 @@ from browser_use.controller.registry.views import ActionModel
 from langchain.tools import BaseTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from pydantic import BaseModel, Field, create_model  # ensure single import for BaseModel and Field
+from src.utils.offline import is_offline  # helper for Codex offline mode
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +93,10 @@ async def setup_mcp_client_and_tools(mcp_server_config: Dict[str, Any]) -> Optio
     """  # expanded docstring
 
     logger.info("Initializing MultiServerMCPClient...")
+
+    if is_offline():  # skip real connection when offline
+        logger.info("Running in CODEX offline mode; MCP client is mocked.")
+        return None  # no connection needed in offline mode
 
     if not mcp_server_config:
         logger.error("No MCP server configuration provided.")

--- a/src/utils/offline.py
+++ b/src/utils/offline.py
@@ -1,0 +1,32 @@
+"""Offline mode utilities and qerrors wrapper."""  # module docstring describing purpose
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def is_offline() -> bool:
+    """Return ``True`` when running in Codex offline mode."""  #// check CODEX env
+    return os.getenv("CODEX") == "True"  # CODEX=True triggers offline behavior
+
+
+def qerrors_stub(error, context="", *extra_args):
+    """Fallback qerrors implementation for offline mode."""  #// stub logs locally
+    logger.error(f"{context}: {error}")  # log error when real qerrors unavailable
+
+
+def qerrors(error, context="", *extra_args):
+    """Call real qerrors when online, otherwise fallback."""  #// central wrapper
+    if is_offline():
+        qerrors_stub(error, context, *extra_args)  # skip real qerrors offline
+    else:
+        try:
+            import qerrors as real_qerrors  # import lazily to avoid missing dep
+            real_qerrors(error, context, *extra_args)
+        except Exception:  # fall back if module missing or call fails
+            qerrors_stub(error, context, *extra_args)
+
+
+__all__ = ["is_offline", "qerrors"]  # export helpers
+


### PR DESCRIPTION
## Summary
- add `is_offline` utility and qerrors stub
- use offline checks in LLM provider
- mock MCP client when CODEX=true
- document CODEX variable and offline mode in README and `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: 'playwright', 'psutil')*

------
https://chatgpt.com/codex/tasks/task_b_683a24703d8c832283a50bbd45a487da