### PR TITLE
Centralize offline checks

### DIFF
--- a/src/utils/mcp_client.py
+++ b/src/utils/mcp_client.py
@@ -79,11 +79,12 @@ from browser_use.controller.registry.views import ActionModel
 from langchain.tools import BaseTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from pydantic import BaseModel, Field, create_model  # ensure single import for BaseModel and Field
-from src.utils.offline import is_offline  # helper for Codex offline mode
+from src.utils.offline import offline_guard  # helper for Codex offline mode; offline_guard handles mocking
 
 logger = logging.getLogger(__name__)
 
 
+@offline_guard(None)  # return None when offline
 async def setup_mcp_client_and_tools(mcp_server_config: Dict[str, Any]) -> Optional[MultiServerMCPClient]:
     """Initialize MCP client and return the connected instance.
 
@@ -93,10 +94,6 @@ async def setup_mcp_client_and_tools(mcp_server_config: Dict[str, Any]) -> Optio
     """  # expanded docstring
 
     logger.info("Initializing MultiServerMCPClient...")
-
-    if is_offline():  # skip real connection when offline
-        logger.info("Running in CODEX offline mode; MCP client is mocked.")
-        return None  # no connection needed in offline mode
 
     if not mcp_server_config:
         logger.error("No MCP server configuration provided.")


### PR DESCRIPTION
## Summary
- centralize offline mode logic in `offline_guard` decorator
- use the decorator for MCP client setup and LLM wrappers
- remove scattered `is_offline` checks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: 'playwright', 'psutil')*

------
https://chatgpt.com/codex/tasks/task_b_683a3348d1f08322959a0c76d2e2fd43