### PR TITLE
Handle missing provider SDKs offline

### DIFF
--- a/src/utils/llm_provider.py
+++ b/src/utils/llm_provider.py
@@ -1,6 +1,27 @@
-from openai import OpenAI
-from langchain_openai import ChatOpenAI
 from src.utils.offline import is_offline  # offline helper for CODEX mode
+
+try:
+    from openai import OpenAI
+except ImportError:  #// handle missing SDK when offline
+    if is_offline():  # fallback only in Codex offline mode
+        class OpenAI:  #// simple dummy class so module loads
+            def __init__(self, *args, **kwargs):
+                pass
+    else:
+        raise
+
+try:
+    from langchain_openai import ChatOpenAI, AzureChatOpenAI
+except ImportError:  #// offline environment without langchain-openai
+    if is_offline():
+        class ChatOpenAI:  #// basic stand-in mimicking real constructor
+            def __init__(self, *args, **kwargs):
+                self.kwargs = kwargs
+
+        class AzureChatOpenAI(ChatOpenAI):
+            pass
+    else:
+        raise
 from langchain_core.globals import get_llm_cache
 from langchain_core.language_models.base import (
     BaseLanguageModel,
@@ -44,7 +65,6 @@ from langchain_anthropic import ChatAnthropic
 from langchain_mistralai import ChatMistralAI
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_ollama import ChatOllama
-from langchain_openai import AzureChatOpenAI, ChatOpenAI
 from langchain_ibm import ChatWatsonx
 from langchain_aws import ChatBedrock
 from pydantic import SecretStr

--- a/tests/components/test_agent_settings_tab.py
+++ b/tests/components/test_agent_settings_tab.py
@@ -3,6 +3,7 @@ import types
 import importlib
 import asyncio
 import json
+import os
 
 sys.path.append('.')
 
@@ -25,8 +26,6 @@ def stub_module(monkeypatch, name, attrs=None):
 def load_agent_settings_tab(monkeypatch):
     """Load agent_settings_tab after injecting stubs for external deps."""  #(added docstring describing helper purpose)
     stubs = [
-        ('openai', {'OpenAI': Dummy}),
-        ('langchain_openai', {'ChatOpenAI': Dummy, 'AzureChatOpenAI': Dummy}),
         ('langchain_ollama', {'ChatOllama': Dummy}),
         ('langchain_anthropic', {'ChatAnthropic': Dummy}),
         ('langchain_mistralai', {'ChatMistralAI': Dummy}),
@@ -64,6 +63,8 @@ def load_agent_settings_tab(monkeypatch):
     ]
     for name, attrs in stubs:
         stub_module(monkeypatch, name, attrs)
+
+    os.environ['CODEX'] = 'True'  # ensure fallback classes load
 
     gradio = stub_module(monkeypatch, 'gradio')
     components = stub_module(monkeypatch, 'gradio.components')

--- a/tests/utils/test_llm_provider.py
+++ b/tests/utils/test_llm_provider.py
@@ -1,6 +1,7 @@
 import sys
 import types
 import importlib
+import os
 import pytest
 
 sys.path.append('.')  # (allow src imports)
@@ -22,8 +23,7 @@ def stub_module(name, attrs=None):
 
 
 # Stub external modules so llm_provider imports without network packages
-stub_module('openai', {'OpenAI': Dummy})  # (create fake OpenAI class)
-stub_module('langchain_openai', {'ChatOpenAI': Dummy, 'AzureChatOpenAI': Dummy})  # (fake openai classes)
+# openai and langchain_openai are handled in the module when CODEX=True
 stub_module('langchain_ollama', {'ChatOllama': Dummy})  # (fake ollama class)
 stub_module('langchain_anthropic', {'ChatAnthropic': Dummy})  # (fake anthropic)
 stub_module('langchain_mistralai', {'ChatMistralAI': Dummy})  # (fake mistral)
@@ -68,6 +68,9 @@ stub_module(
 stub_module('langchain_core.output_parsers.base', {'OutputParserLike': Dummy})  # (fake parser)
 stub_module('langchain_core.runnables', {'Runnable': Dummy, 'RunnableConfig': Dummy})  # (fake runnables)
 stub_module('langchain_core.tools', {'BaseTool': Dummy})  # (fake tools)
+
+# enable offline mode so llm_provider creates fallback classes
+os.environ['CODEX'] = 'True'
 
 llm_provider = importlib.import_module('src.utils.llm_provider')  # (import target module)
 


### PR DESCRIPTION
## Summary
- add offline import fallbacks for openai and langchain_openai
- remove manual stubs in llm provider tests
- enable CODEX in component tests to exercise fallbacks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_b_683a494a7a7083228150cb3373f41f84