### PR TITLE
Fix offline_guard metadata preservation

### DIFF
--- a/src/utils/mcp_client.py
+++ b/src/utils/mcp_client.py
@@ -79,7 +79,7 @@ from browser_use.controller.registry.views import ActionModel
 from langchain.tools import BaseTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from pydantic import BaseModel, Field, create_model  # ensure single import for BaseModel and Field
-from src.utils.offline import offline_guard  # helper for Codex offline mode; offline_guard handles mocking
+from src.utils.offline import is_offline, offline_guard  # helper for Codex offline mode; offline_guard handles mocking and is_offline checks
 
 logger = logging.getLogger(__name__)
 

--- a/src/utils/offline.py
+++ b/src/utils/offline.py
@@ -3,6 +3,7 @@
 import logging  # handle debug logs centrally
 import os  # env vars for offline detection
 import asyncio  # check coroutine functions for decorator
+from functools import wraps  # preserve function metadata when decorating
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,7 @@ def offline_guard(mock_return):
     """Return decorator that provides ``mock_return`` when offline."""  #// central offline wrapper
     def decorator(func):
         if asyncio.iscoroutinefunction(func):
+            @wraps(func)  # maintain original function metadata when decorated
             async def async_wrapper(*args, **kwargs):
                 if is_offline():  # return mock object when CODEX True
                     logger.info(f"{func.__name__} mocked due to offline mode")
@@ -40,6 +42,7 @@ def offline_guard(mock_return):
                 return await func(*args, **kwargs)
             return async_wrapper
         else:
+            @wraps(func)  # maintain original function metadata when decorated
             def wrapper(*args, **kwargs):
                 if is_offline():  # return mock object when CODEX True
                     logger.info(f"{func.__name__} mocked due to offline mode")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,8 @@ for name in mods:
     elif name.endswith("browser.views"):
         setattr(mod, "BrowserState", getattr(mod, "BrowserState", type("BrowserState", (), {})))
 
+sys.modules.setdefault("psutil", types.ModuleType("psutil"))  #// stub psutil for environments without it
+
 def pytest_ignore_collect(path, config):  #(description of change & current functionality)
     """Skip integration tests when gradio is unavailable."""  #(added docstring explaining hook purpose)
     if path.basename in {"test_webui_integration.py", "test_interface.py", "test_run_deep_research.py"}:  #(description of change & current functionality)

--- a/tests/integration/test_run_agent_task.py
+++ b/tests/integration/test_run_agent_task.py
@@ -240,7 +240,10 @@ def test_run_agent_task_simple(tmp_path):
     WebuiManager = importlib.import_module("src.webui.webui_manager").WebuiManager
     bu_tab = importlib.import_module("src.webui.components.browser_use_agent_tab")
 
+    import os
+
     async def runner():
+        os.environ["CODEX"] = "True"  #// enable offline mode to bypass Playwright import
         manager = WebuiManager(settings_save_dir=str(tmp_path))
         manager.init_browser_use_agent()
 
@@ -285,6 +288,7 @@ def test_run_agent_task_simple(tmp_path):
         assert not final_update[pause_button].interactive
         assert final_update[clear_button].interactive
         assert final_update[chatbot].value == manager.bu_chat_history
+        os.environ.pop("CODEX", None)  #// cleanup offline flag
 
     asyncio.run(runner())
     for name, mod in {

--- a/tests/test_browser_launch.py
+++ b/tests/test_browser_launch.py
@@ -8,17 +8,20 @@ from src.utils.browser_launch import build_browser_launch_options  # import util
 def test_default_behavior_without_env(monkeypatch):
     """Use default config when no environment overrides are provided."""  #(added docstring summarizing test intent)
     # use defaults when env vars absent
+    monkeypatch.setenv("CODEX", "True")  #// enable offline mode to avoid Playwright import
     monkeypatch.delenv("CHROME_PATH", raising=False)  # remove env path
     monkeypatch.delenv("CHROME_USER_DATA", raising=False)  # remove env data
     config = {"window_width": 800, "window_height": 600, "use_own_browser": False}  # default config
     path, args = build_browser_launch_options(config)  # call util
     assert path is None  # expect None path
     assert args == ["--window-size=800,600"]  # only window size
+    monkeypatch.delenv("CODEX", raising=False)  #// cleanup offline flag
 
 
 def test_own_browser_env(monkeypatch):
     """Environment variables take precedence over config options."""  #(added docstring summarizing test intent)
     # prefer env variables over config
+    monkeypatch.setenv("CODEX", "True")  #// enable offline mode to avoid Playwright import
     monkeypatch.setenv("CHROME_PATH", "/env/chrome")  # set env path
     monkeypatch.setenv("CHROME_USER_DATA", "/env/profile")  # set env data
     config = {
@@ -35,11 +38,13 @@ def test_own_browser_env(monkeypatch):
         "--user-data-dir=/config/profile",
         "--user-data-dir=/env/profile",
     ]  # all args present
+    monkeypatch.delenv("CODEX", raising=False)  #// cleanup offline flag
 
 
 def test_empty_env_path(monkeypatch):
     """Ensure empty CHROME_PATH environment variable is treated as None."""  #(added docstring summarizing test intent)
     # empty CHROME_PATH results in None
+    monkeypatch.setenv("CODEX", "True")  #// enable offline mode to avoid Playwright import
     monkeypatch.setenv("CHROME_PATH", "")  # empty env value
     monkeypatch.delenv("CHROME_USER_DATA", raising=False)  # no env data
     config = {
@@ -51,3 +56,4 @@ def test_empty_env_path(monkeypatch):
     path, args = build_browser_launch_options(config)  # call util
     assert path is None  # empty env results in None
     assert args == ["--window-size=1024,768"]  # only window size arg
+    monkeypatch.delenv("CODEX", raising=False)  #// cleanup offline flag

--- a/tests/utils/test_offline_guard.py
+++ b/tests/utils/test_offline_guard.py
@@ -1,0 +1,40 @@
+import sys  #// allow src imports
+import asyncio  #// used for async test
+sys.path.append('.')  #// include project root
+from src.utils.offline import offline_guard  #// decorator under test
+
+
+def test_offline_guard_preserves_metadata(monkeypatch):
+    """Ensure name and docstring survive wrapping."""  #// verify sync functions
+    monkeypatch.delenv("CODEX", raising=False)  #// start online
+
+    @offline_guard('mock')
+    def sample():
+        """doc string"""  #// baseline doc
+        return 'real'
+
+    assert sample.__name__ == 'sample'  #// name intact
+    assert sample.__doc__ == 'doc string'  #// docstring intact
+    monkeypatch.setenv('CODEX', 'True')  #// enable offline mode
+    assert sample() == 'mock'  #// decorator returns mock offline
+    monkeypatch.delenv('CODEX', raising=False)  #// cleanup
+
+
+import pytest  #// pytest for asyncio marker
+
+
+@pytest.mark.asyncio
+async def test_offline_guard_preserves_metadata_async(monkeypatch):
+    """Async functions should keep metadata."""  #// verify async path
+    monkeypatch.delenv('CODEX', raising=False)  #// start online
+
+    @offline_guard('mock')
+    async def async_fn():
+        """async doc"""  #// baseline async doc
+        return 'real'
+
+    assert async_fn.__name__ == 'async_fn'  #// name intact
+    assert async_fn.__doc__ == 'async doc'  #// docstring intact
+    monkeypatch.setenv('CODEX', 'True')  #// enable offline mode
+    assert await async_fn() == 'mock'  #// decorator returns mock offline
+    monkeypatch.delenv('CODEX', raising=False)  #// cleanup

--- a/tests/utils/test_offline_imports.py
+++ b/tests/utils/test_offline_imports.py
@@ -73,8 +73,9 @@ def test_llm_provider_offline(monkeypatch):
     stub_module("langchain_core.load", {"dumpd": lambda *a, **k: {}, "dumps": lambda *a, **k: ""})  #// stub dumps
 
     class Message:
-        def __init__(self, content=""):
+        def __init__(self, content="", reasoning_content=""):
             self.content = content  #// store message content
+            self.reasoning_content = reasoning_content  #// store reasoning text
 
     stub_module(
         "langchain_core.messages",


### PR DESCRIPTION
## Summary
- keep function metadata when using offline_guard
- fix missing is_offline import in mcp_client
- cover offline_guard with tests
- stub psutil module in tests
- ensure browser launch and agent tests run without Playwright

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683af82f54308322a18770120014daec