### PR TITLE
Fix unused async_playwright stub

### DIFF
--- a/src/utils/browser_launch.py
+++ b/src/utils/browser_launch.py
@@ -73,9 +73,7 @@ def build_browser_launch_options(config: Dict[str, Any]) -> Tuple[Optional[str],
     Environment variables ``CHROME_PATH`` and ``CHROME_USER_DATA`` override
     path settings when ``use_own_browser`` is true.
     """  # function description expanded
-    if is_offline():  # load local stub when offline
-        async_playwright = lambda: None  # minimal mock for tests
-    else:
+    if not is_offline():  # only import when online; offline mode uses no import
         from playwright.async_api import async_playwright  # import lazily when online
     window_w = config.get("window_width", 1280)  # width from config; default 1280
     window_h = config.get("window_height", 1100)  # height from config; default 1100


### PR DESCRIPTION
## Summary
- remove unused async_playwright offline stub

## Testing
- `CODEX=True pytest tests/test_browser_launch.py::test_default_behavior_without_env -q`
- `CODEX=True pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_b_683af835c93c832293c9482ade2e3c7d