### PR TITLE
Add falsy cases for offline detection

### DIFF
--- a/tests/utils/test_offline_detection.py
+++ b/tests/utils/test_offline_detection.py
@@ -10,3 +10,14 @@ def test_is_offline_truthy_values(monkeypatch):
         assert is_offline()  # detection should succeed
         monkeypatch.delenv("CODEX", raising=False)  # clean env between cases
 
+
+def test_is_offline_falsey_values(monkeypatch):
+    """Return False when CODEX unset or falsy."""  # docstring summarizing test
+    for val in [None, "", "False", "false", "0"]:  # iterate falsy options
+        if val is not None:  # set CODEX only when value provided
+            monkeypatch.setenv("CODEX", val)  # apply env var for test
+        else:
+            monkeypatch.delenv("CODEX", raising=False)  # ensure var unset
+        assert not is_offline()  # detection should fail
+        monkeypatch.delenv("CODEX", raising=False)  # cleanup between cases
+


### PR DESCRIPTION
## Summary
- expand offline detection tests

## Testing
- `pytest -q tests/utils/test_offline_detection.py`

------
https://chatgpt.com/codex/tasks/task_b_683b501e0640832280ac391cb6361907