### PR TITLE
Remove pdb debugging from tests

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,5 +1,4 @@
-import pdb
-import pytest  # (import for importorskip)
+import pytest  # (import for importorskip) #(pdb import removed, tests run without debug)
 pytest.importorskip("dotenv", reason="python-dotenv required")  # (skip if dotenv missing)
 
 from dotenv import load_dotenv
@@ -326,9 +325,7 @@ async def test_browser_use_parallel():
         pprint(history.final_result(), indent=4)
 
         print("\nErrors:")
-        pprint(history.errors(), indent=4)
-
-        pdb.set_trace()
+        pprint(history.errors(), indent=4)  # (removed pdb.set_trace to avoid interactive debug)
 
     except Exception:
         import traceback


### PR DESCRIPTION
## Summary
- clean up agents test
- remove `pdb` import and debug call

## Testing
- `pytest -k test_agents -q`

------
https://chatgpt.com/codex/tasks/task_b_683bcc868bac832284244c7fd14f2126