### PR TITLE
Fix MCP client cleanup on browser resets

### DIFF
--- a/src/webui/components/browser_settings_tab.py
+++ b/src/webui/components/browser_settings_tab.py
@@ -93,6 +93,9 @@ async def close_browser(webui_manager: WebuiManager):  # cancel tasks and releas
         webui_manager.bu_browser_context = None  # reset context reference when present
     if hasattr(webui_manager, "bu_browser"):
         webui_manager.bu_browser = None  # reset browser reference when present
+    if getattr(webui_manager, "bu_controller", None):
+        await webui_manager.bu_controller.close_mcp_client()  # close remote client before discard
+        webui_manager.bu_controller = None  # drop controller reference after closing
 
 def create_browser_settings_tab(webui_manager: WebuiManager):
     """

--- a/src/webui/components/browser_use_agent_tab.py
+++ b/src/webui/components/browser_use_agent_tab.py
@@ -745,8 +745,10 @@ async def handle_clear(webui_manager: WebuiManager) -> Dict[Component, Any]:
     if webui_manager.bu_current_task and not webui_manager.bu_current_task.done():
         webui_manager.bu_current_task.cancel()
     await close_browser(webui_manager)
+    if getattr(webui_manager, "bu_controller", None):
+        await webui_manager.bu_controller.close_mcp_client()  # close remote client before reset
     webui_manager.bu_agent = None
-    webui_manager.bu_controller = None
+    webui_manager.bu_controller = None  # drop controller after closing client
     webui_manager.bu_current_task = None
     webui_manager.bu_chat_history = []
     webui_manager.bu_response_event = None


### PR DESCRIPTION
## Summary
- close the MCP client when shutting down browser resources
- ensure `handle_clear` closes MCP client before clearing controller

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683be29a76188322ac56ae63d294b70d