### PR TITLE
Fix callback ordering for components

### DIFF
--- a/src/webui/components/agent_settings_tab.py
+++ b/src/webui/components/agent_settings_tab.py
@@ -94,7 +94,7 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
     """
     Creates an agent settings tab.
     """
-    input_components = set(webui_manager.get_components())
+    input_components = list(webui_manager.get_components())  # // maintain order when referencing components
     tab_components = {}
 
     with gr.Row():  # two columns to keep system prompt inputs aligned

--- a/src/webui/components/browser_settings_tab.py
+++ b/src/webui/components/browser_settings_tab.py
@@ -101,7 +101,7 @@ def create_browser_settings_tab(webui_manager: WebuiManager):
     """
     Creates a browser settings tab.
     """
-    input_components = set(webui_manager.get_components())
+    input_components = list(webui_manager.get_components())  # // maintain order when referencing components
     tab_components = {}
 
     with gr.Group():  # group path settings separately for clarity

--- a/src/webui/components/browser_use_agent_tab.py
+++ b/src/webui/components/browser_use_agent_tab.py
@@ -819,9 +819,10 @@ def create_browser_use_agent_tab(webui_manager: WebuiManager):
     webui_manager.init_browser_use_agent()
 
     tab_outputs = list(tab_components.values())
-    all_inputs = set(webui_manager.get_components())
+    all_inputs = list(webui_manager.get_components())  # // keep order for correct value mapping
 
-    async def submit_wrapper(comps: Dict[Component, Any]) -> AsyncGenerator[Dict[Component, Any], None]:
+    async def submit_wrapper(*vals) -> AsyncGenerator[Dict[Component, Any], None]:  # // build comps dict from ordered values
+        comps = dict(zip(all_inputs, vals))  # // map components to values for handler
         async for upd in handle_submit(webui_manager, comps):
             yield upd
 

--- a/src/webui/components/deep_research_agent_tab.py
+++ b/src/webui/components/deep_research_agent_tab.py
@@ -351,7 +351,7 @@ def create_deep_research_agent_tab(webui_manager: WebuiManager):
     """
     Creates a deep research agent tab
     """
-    input_components = set(webui_manager.get_components())
+    input_components = list(webui_manager.get_components())  # // maintain order when referencing components
     tab_components = {}
 
     with gr.Group():  # file selection separate from rest of form
@@ -407,10 +407,11 @@ def create_deep_research_agent_tab(webui_manager: WebuiManager):
     )
 
     dr_tab_outputs = list(tab_components.values())
-    all_managed_inputs = set(webui_manager.get_components())
+    all_managed_inputs = list(webui_manager.get_components())  # // keep defined order for value mapping
 
     # --- Define Event Handler Wrappers ---
-    async def start_wrapper(comps: Dict[Component, Any]) -> AsyncGenerator[Dict[Component, Any], None]:  # relay start button event
+    async def start_wrapper(*vals) -> AsyncGenerator[Dict[Component, Any], None]:  # // build comps dict from ordered values
+        comps = dict(zip(all_managed_inputs, vals))  # // map components to values for handler
         async for update in run_deep_research(webui_manager, comps):
             yield update
 

--- a/src/webui/components/load_save_config_tab.py
+++ b/src/webui/components/load_save_config_tab.py
@@ -86,7 +86,7 @@ def create_load_save_config_tab(webui_manager: WebuiManager):
     """
     Creates a load and save config tab.
     """
-    input_components = set(webui_manager.get_components())
+    input_components = list(webui_manager.get_components())  # // maintain order when referencing components
     tab_components = {}
 
     # Load most recent config on startup
@@ -122,9 +122,15 @@ def create_load_save_config_tab(webui_manager: WebuiManager):
 
     webui_manager.add_components("load_save_config", tab_components)  # register load/save widgets for persistence
 
+    all_components = list(webui_manager.get_components())  # // inputs for saving config in consistent order
+
+    def save_wrapper(*vals):  # // map ordered values back to components
+        comps = dict(zip(all_components, vals))  # // create {Component: value} mapping
+        return webui_manager.save_config(comps)  # // call manager save
+
     save_config_button.click(
-        fn=webui_manager.save_config,  # persist current settings to file
-        inputs=set(webui_manager.get_components()),
+        fn=save_wrapper,  # persist current settings to file
+        inputs=all_components,
         outputs=[config_status]
     )
 


### PR DESCRIPTION
## Summary
- keep component order stable by switching set -> list
- build component dict in wrappers using zip so handlers get correct inputs
- adapt save wrapper to map ordered values when saving config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683d425bb2f48322918b4a9dc275de97