### PR TITLE
Fix stop_deep_research component lookup

### DIFF
--- a/src/webui/components/deep_research_agent_tab.py
+++ b/src/webui/components/deep_research_agent_tab.py
@@ -325,7 +325,7 @@ async def stop_deep_research(webui_manager: WebuiManager) -> Dict[Component, Any
             stop_button_comp: gr.update(interactive=False),
             webui_manager.get_component_by_id("deep_research_agent.research_task"): gr.update(interactive=True),
             webui_manager.get_component_by_id("deep_research_agent.resume_task_id"): gr.update(interactive=True),
-            webui_manager.get_component_by_id("deep_research_agent.max_iteration"): gr.update(interactive=True),
+            webui_manager.get_component_by_id("deep_research_agent.parallel_num"): gr.update(interactive=True),  # // correct component for parallel agents
             webui_manager.get_component_by_id("deep_research_agent.max_query"): gr.update(interactive=True),
         }
 

--- a/tests/components/test_deep_research_agent_tab.py
+++ b/tests/components/test_deep_research_agent_tab.py
@@ -154,8 +154,8 @@ def test_stop_deep_research_running(monkeypatch, tmp_path):
     mgr = DummyManager()
     names = [
         "stop_button", "start_button", "markdown_display", "markdown_download",
-        "research_task", "resume_task_id", "max_iteration", "max_query"
-    ]
+        "research_task", "resume_task_id", "parallel_num", "max_query"
+    ]  # // updated component id list to match code changes
     for name in names:
         mgr.components[f"deep_research_agent.{name}"] = DummyComp()
     mgr.dr_agent = DummyAgent()


### PR DESCRIPTION
## Summary
- correct the component id used to re-enable parallel count in `stop_deep_research`
- update the unit test component list accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683d528b28ac83229960f13c2d5ea095