### PR TITLE
Fix step numbering in chat history

### DIFF
--- a/src/webui/components/browser_use_agent_tab.py
+++ b/src/webui/components/browser_use_agent_tab.py
@@ -224,8 +224,7 @@ async def _handle_new_step(
         # Initialize it maybe? Or raise an error? For now, log and potentially skip chat update.
         webui_manager.bu_chat_history = []  # Initialize if missing (consider if this is the right place)
         # return # Or stop if this is critical
-    step_num -= 1
-    logger.info(f"Step {step_num} completed.")
+    logger.info(f"Step {step_num} completed.")  # step numbers now reflect actual agent steps
 
     # --- Screenshot Handling ---
     screenshot_html = ""


### PR DESCRIPTION
## Summary
- avoid decrementing step_num when handling new steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683d69818eb88322a003927d9b7a12be