### PR TITLE
Reset MCP client after exit

### DIFF
--- a/src/controller/custom_controller.py
+++ b/src/controller/custom_controller.py
@@ -198,3 +198,4 @@ class CustomController(Controller):
         """  # added docstring for explaining graceful shutdown use
         if self.mcp_client:
             await self.mcp_client.__aexit__(None, None, None)  # graceful shutdown of MCP session
+            self.mcp_client = None  # (reset after closing & free resources)

--- a/tests/controller/test_custom_controller.py
+++ b/tests/controller/test_custom_controller.py
@@ -146,8 +146,10 @@ def test_register_and_close(monkeypatch):
     assert action.function is controller.mcp_client.server_name_to_tools['srv'][0]
     assert action.param_model == 'model'
     assert controller.mcp_client.entered
+    client = controller.mcp_client  # capture client for post-close checks
     asyncio.run(controller.close_mcp_client())
-    assert controller.mcp_client.exited
+    assert client.exited  # verify client exit invoked
+    assert controller.mcp_client is None  # (controller resets mcp_client)
 
     sys.modules.pop('src.controller.custom_controller', None)
     sys.modules.pop('src.utils.mcp_client', None)


### PR DESCRIPTION
## Summary
- reset `mcp_client` to `None` when closing MCP connection
- adjust unit test to check the client resets properly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683d69840d388322b3e02af0b7f9263c