### PR TITLE
Handle missing LLM init

### DIFF
--- a/src/webui/components/browser_use_agent_tab.py
+++ b/src/webui/components/browser_use_agent_tab.py
@@ -557,6 +557,18 @@ async def run_agent_task(
         ollama_num_ctx if llm_provider_name == "ollama" else None,
     )
 
+    if main_llm is None:  # // check that llm initialization succeeded
+        err_msg = "**Setup Error:** LLM initialization failed"  # // error text for chatbot
+        webui_manager.bu_chat_history.append({"role": "assistant", "content": err_msg})  # // log error to chat history
+        yield {  # // reset UI buttons on init failure
+            run_button_comp: gr.Button(value="▶️ Submit Task", interactive=True),  # // enable run button
+            stop_button_comp: gr.Button(interactive=False),  # // disable stop button
+            pause_resume_button_comp: gr.Button(interactive=False),  # // disable pause/resume
+            clear_button_comp: gr.Button(interactive=False),  # // disable clear to avoid wiping history accidentally
+            chatbot_comp: gr.update(value=webui_manager.bu_chat_history),  # // display error message
+        }
+        return  # // abort run when llm is missing
+
     # Pass the webui_manager instance to the callback when wrapping it
     async def ask_callback_wrapper(
         query: str, browser_context: BrowserContext

--- a/tests/components/test_browser_use_agent_tab_buttons.py
+++ b/tests/components/test_browser_use_agent_tab_buttons.py
@@ -112,7 +112,7 @@ def load_tab(monkeypatch):
 
     utils_mod = types.ModuleType("src.utils.agent_utils")
     async def initialize_llm(*a, **k):
-        return None
+        return object()
     utils_mod.initialize_llm = initialize_llm
     monkeypatch.setitem(sys.modules, "src.utils.agent_utils", utils_mod)
 

--- a/tests/components/test_browser_use_agent_tab_helpers.py
+++ b/tests/components/test_browser_use_agent_tab_helpers.py
@@ -50,7 +50,7 @@ def install_stubs():
     modules["src.browser.custom_browser"].CustomBrowser = type("CustomBrowser", (), {})
     modules["src.browser.custom_context"].CustomBrowserContextConfig = type("CustomBrowserContextConfig", (), {})
     modules["src.controller.custom_controller"].CustomController = type("CustomController", (), {})
-    modules["src.utils.agent_utils"].initialize_llm = lambda *a, **k: None
+    modules["src.utils.agent_utils"].initialize_llm = lambda *a, **k: object()
     modules["src.utils.browser_launch"].build_browser_launch_options = lambda *a, **k: (None, [])
 
     class DummyWebuiManager:

--- a/tests/integration/test_run_agent_task.py
+++ b/tests/integration/test_run_agent_task.py
@@ -213,7 +213,7 @@ def setup_stubs():
 
     utils_module = types.ModuleType("src.utils.agent_utils")
     async def initialize_llm(*a, **k):
-        return None
+        return object()
     utils_module.initialize_llm = initialize_llm
     modules["src.utils.agent_utils"] = utils_module
 


### PR DESCRIPTION
## Summary
- show error and disable controls when LLm initialization fails
- adjust tests to return dummy object instead of None when stubbing `initialize_llm`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683d7f9c687483228f4504bf44409b46