### PR TITLE
Add fallback to Playwright imports

### DIFF
--- a/src/browser/custom_browser.py
+++ b/src/browser/custom_browser.py
@@ -1,14 +1,24 @@
 """Custom browser implementation with enhanced setup."""  # module docstring summarizing purpose
 import asyncio
 
-from patchright.async_api import Browser as PlaywrightBrowser
-from patchright.async_api import (
-    BrowserContext as PlaywrightBrowserContext,
-)
-from patchright.async_api import (
-    Playwright,
-    async_playwright,
-)
+try:  # attempt patchright first for browser automation
+    from patchright.async_api import Browser as PlaywrightBrowser  # use patchright Browser when available
+    from patchright.async_api import (
+        BrowserContext as PlaywrightBrowserContext,
+    )
+    from patchright.async_api import (
+        Playwright,
+        async_playwright,
+    )
+except ImportError:  # fallback to upstream playwright if patchright missing
+    from playwright.async_api import Browser as PlaywrightBrowser
+    from playwright.async_api import (
+        BrowserContext as PlaywrightBrowserContext,
+    )
+    from playwright.async_api import (
+        Playwright,
+        async_playwright,
+    )
 from browser_use.browser.browser import Browser, IN_DOCKER
 from browser_use.browser.context import BrowserContext, BrowserContextConfig  # deduped duplicate import
 import logging  # removed extra PlaywrightBrowserContext import

--- a/src/browser/custom_context.py
+++ b/src/browser/custom_context.py
@@ -5,8 +5,12 @@ import os
 
 from browser_use.browser.browser import Browser, IN_DOCKER
 from browser_use.browser.context import BrowserContext, BrowserContextConfig
-from patchright.async_api import Browser as PlaywrightBrowser
-from patchright.async_api import BrowserContext as PlaywrightBrowserContext
+try:  # try patchright for extended features
+    from patchright.async_api import Browser as PlaywrightBrowser
+    from patchright.async_api import BrowserContext as PlaywrightBrowserContext
+except ImportError:  # fallback to playwright on failure
+    from playwright.async_api import Browser as PlaywrightBrowser
+    from playwright.async_api import BrowserContext as PlaywrightBrowserContext
 from typing import Optional
 from browser_use.browser.context import BrowserContextState
 


### PR DESCRIPTION
## Summary
- fallback to `playwright.async_api` if `patchright.async_api` isn't available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683dbc366094832281c6211bc4fc945d