### PR TITLE
Fix duplicate MCP parsing in browser agent

### DIFF
--- a/src/webui/components/browser_use_agent_tab.py
+++ b/src/webui/components/browser_use_agent_tab.py
@@ -422,24 +422,7 @@ async def run_agent_task(
         yield {run_button_comp: gr.update(interactive=True)}
         return
 
-    mcp_server_config_comp = webui_manager.id_to_component.get(  #(description of change & current functionality)
-        "agent_settings.mcp_server_config"  #(description of change & current functionality)
-    )
-    mcp_server_config_str = (  #(description of change & current functionality)
-        components.get(mcp_server_config_comp) if mcp_server_config_comp else None
-    )
-    if mcp_server_config_str:  #(description of change & current functionality)
-        try:  #(description of change & current functionality)
-            mcp_server_config = json.loads(mcp_server_config_str)  #(description of change & current functionality)
-        except json.JSONDecodeError:  #(description of change & current functionality)
-            err_msg = "**Setup Error:** invalid MCP config"  #(description of change & current functionality)
-            yield {  #(description of change & current functionality)
-                run_button_comp: gr.Button(interactive=True),  #(description of change & current functionality)
-                chatbot_comp: gr.update(value=[{"role": "assistant", "content": err_msg}]),  #(description of change & current functionality)
-            }
-            return  #(description of change & current functionality)
-    else:  #(description of change & current functionality)
-        mcp_server_config = None  #(description of change & current functionality)
+    # MCP config parsed later  #(description of change & current functionality)
 
     # Set running state indirectly via _current_task
     webui_manager.bu_chat_history.append({"role": "user", "content": task})

--- a/tests/integration/test_run_agent_task.py
+++ b/tests/integration/test_run_agent_task.py
@@ -406,8 +406,8 @@ def test_run_agent_task_invalid_mcp_config(tmp_path):
 
         updates = [u async for u in bu_tab.run_agent_task(manager, components)]
 
-        assert len(updates) == 1
-        msg = updates[0][chatbot].value[-1]["content"]
+        assert len(updates) == 2  # MCP config error occurs after initial state update
+        msg = updates[-1][chatbot].value[-1]["content"]
         assert msg.startswith("**Setup Error:**")
 
     asyncio.run(runner())


### PR DESCRIPTION
## Notes
- remove early MCP config parsing so it occurs only once
- update failing test expectation

## Summary
- delete duplicate MCP config parsing block in `browser_use_agent_tab.run_agent_task`
- adjust test to expect two updates when invalid MCP config is supplied

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683dbc2baf3083228974e4ec6bd37e77