### PR TITLE
Remove unused variable from deep research tab

### DIFF
--- a/src/webui/components/deep_research_agent_tab.py
+++ b/src/webui/components/deep_research_agent_tab.py
@@ -351,8 +351,7 @@ def create_deep_research_agent_tab(webui_manager: WebuiManager):
     """
     Creates a deep research agent tab
     """
-    input_components = list(webui_manager.get_components())  # // maintain order when referencing components
-    tab_components = {}
+    tab_components = {}  # // removed unused input_components variable
 
     with gr.Group():  # file selection separate from rest of form
         with gr.Row():


### PR DESCRIPTION
## Summary
- clean up `create_deep_research_agent_tab`
- remove unused variable and add explanatory comment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683e0050cb708322b6c6c923e2c01ade