### PR TITLE
Fix pause/resume await

### DIFF
--- a/src/webui/components/browser_use_agent_tab.py
+++ b/src/webui/components/browser_use_agent_tab.py
@@ -714,9 +714,9 @@ async def handle_pause_resume(webui_manager: WebuiManager) -> Dict[Component, An
     if not agent or not task or task.done():
         return {}
     if getattr(agent.state, "paused", False):
-        agent.resume()
+        await agent.resume()  # (await agent resume to handle async call)
         return {pause_button: gr.update(value="⏸️ Pause", interactive=True)}
-    agent.pause()
+    await agent.pause()  # (await agent pause to handle async call)
     return {pause_button: gr.update(value="▶️ Resume", interactive=True)}
 
 

--- a/tests/components/test_browser_use_agent_tab_buttons.py
+++ b/tests/components/test_browser_use_agent_tab_buttons.py
@@ -84,9 +84,9 @@ def load_tab(monkeypatch):
     class DummyAgent:
         def __init__(self):
             self.state = types.SimpleNamespace(paused=False, stopped=False)
-        def pause(self):
+        async def pause(self):  # (make async to match awaited calls)
             self.state.paused = True
-        def resume(self):
+        async def resume(self):  # (make async to match awaited calls)
             self.state.paused = False
         def stop(self):
             self.state.stopped = True


### PR DESCRIPTION
## Summary
- await `agent.resume` and `agent.pause` calls
- adjust dummy agent in tests to use async pause/resume

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683e213ddfe0832294c720007ad1d321